### PR TITLE
Move cron example from docs to examples

### DIFF
--- a/aws-node-scheduled-cron/README.md
+++ b/aws-node-scheduled-cron/README.md
@@ -1,14 +1,6 @@
 # AWS Node Scheduled Cron Example
 
-This is an example of creating a function that runs as a cron job.
-
-To see your job running tail your logs with:
-
-```bash
-serverless logs -function cron -tail
-```
-
-For more information on `schedule` event check out [our docs](https://serverless.com/framework/docs/providers/aws/events/schedule/).
+This is an example of creating a function that runs as a cron job using the serverless `schedule` event. For more information on `schedule` event check out [our docs](https://serverless.com/framework/docs/providers/aws/events/schedule/).
 
 Schedule events use the `rate` or `cron` syntax.
 
@@ -42,6 +34,14 @@ All fields are required and time zone is UTC only.
 | Year          | 1970-2199      | , - * /       |
 
 Read the [AWS cron expression syntax](http://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html) docs for more info on how to setup cron
+
+## Running
+
+To see your cron job running tail your logs with:
+
+```bash
+serverless logs -function cron -tail
+```
 
 ## Additonal Resources
 

--- a/aws-node-scheduled-cron/README.md
+++ b/aws-node-scheduled-cron/README.md
@@ -101,4 +101,4 @@ serverless logs --function secondCron --tail
 
 ## Additonal Resources
 
-For more information on running cron with Serverless check out the [Tutorial: Serverless Scheduled Tasks](https://parall.ax/blog/view/3202/tutorial-serverless-scheduled-tasks) by parallax.
+For more information on running cron with Serverless check out the [Tutorial: Serverless Scheduled Tasks](https://parall.ax/blog/view/3202/tutorial-serverless-scheduled-tasks) by Parallax.

--- a/aws-node-scheduled-cron/README.md
+++ b/aws-node-scheduled-cron/README.md
@@ -1,0 +1,28 @@
+# AWS Node Scheduled Cron Example
+
+This is an example of creating a function that runs as a cron job.
+
+To see your job running tail your logs with:
+
+```bash
+serverless logs -function cron -tail
+```
+
+## Cron syntax
+
+```pseudo
+cron(Minutes Hours Day-of-month Month Day-of-week Year)
+```
+
+All fields are required and time zone is UTC only.
+
+| Field         | Values         | Wildcards     |
+| ------------- |:--------------:|:-------------:|
+| Minutes       | 0-59           | , - * /       |
+| Hours         | 0-23           | , - * /       |
+| Day-of-month  | 1-31           | , - * ? / L W |
+| Month         | 1-12 or JAN-DEC| , - * /       |
+| Day-of-week   | 1-7 or SUN-SAT | , - * ? / L # |
+| Year          | 1970-2199      | , - * /       |
+
+Read the [AWS cron expression syntax](http://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html) docs for more info on how to setup cron

--- a/aws-node-scheduled-cron/README.md
+++ b/aws-node-scheduled-cron/README.md
@@ -8,6 +8,22 @@ To see your job running tail your logs with:
 serverless logs -function cron -tail
 ```
 
+For more information on `schedule` event check out [our docs](https://serverless.com/framework/docs/providers/aws/events/schedule/).
+
+Schedule events use the `rate` or `cron` syntax.
+
+## Rate syntax
+
+```pseudo
+rate(value unit)
+```
+
+`value` - A positive number
+
+`unit` - The unit of time. ( minute | minutes | hour | hours | day | days )
+
+For more [information on the rate syntax see the AWS docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions)
+
 ## Cron syntax
 
 ```pseudo
@@ -26,3 +42,7 @@ All fields are required and time zone is UTC only.
 | Year          | 1970-2199      | , - * /       |
 
 Read the [AWS cron expression syntax](http://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html) docs for more info on how to setup cron
+
+## Additonal Resources
+
+For more information on running cron with Serverless check out the [Tutorial: Serverless Scheduled Tasks](https://parall.ax/blog/view/3202/tutorial-serverless-scheduled-tasks) by parallax.

--- a/aws-node-scheduled-cron/README.md
+++ b/aws-node-scheduled-cron/README.md
@@ -1,6 +1,6 @@
 # AWS Node Scheduled Cron Example
 
-This is an example of creating a function that runs as a cron job using the serverless `schedule` event. For more information on `schedule` event check out [our docs](https://serverless.com/framework/docs/providers/aws/events/schedule/).
+This is an example of creating a function that runs as a cron job using the serverless `schedule` event. For more information on `schedule` event check out the Serverless docs on [schedule](https://serverless.com/framework/docs/providers/aws/events/schedule/).
 
 Schedule events use the `rate` or `cron` syntax.
 
@@ -37,12 +37,66 @@ All fields are required and time zone is UTC only.
 
 Read the [AWS cron expression syntax](http://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html) docs for more info on how to setup cron
 
-## Running
+## Deploy
+
+In order to deploy the you endpoint simply run
+
+```bash
+serverless deploy
+```
+
+The expected result should be similar to:
+
+```bash
+Serverless: Packaging service...
+Serverless: Uploading CloudFormation file to S3...
+Serverless: Uploading service .zip file to S3 (1.47 KB)...
+Serverless: Updating Stack...
+Serverless: Checking Stack update progress...
+..............
+Serverless: Stack update finished...
+
+Service Information
+service: scheduled-cron-example
+stage: dev
+region: us-east-1
+api keys:
+  None
+endpoints:
+  None
+functions:
+  scheduled-cron-example-dev-cron: arn:aws:lambda:us-east-1:377024778620:function:scheduled-cron-example-dev-cron
+  scheduled-cron-example-dev-secondCron: arn:aws:lambda:us-east-1:377024778620:function:scheduled-cron-example-dev-secondCron
+```
+
+There is no additional step required. Your defined schedule becomes active right away after deployment.
+
+## Usage
 
 To see your cron job running tail your logs with:
 
 ```bash
 serverless logs --function cron --tail
+```
+
+The expected result should be similar to:
+
+```bash
+START RequestId: e6e64a4e-b57d-11e6-9eee-0340b40f6d48 Version: $LATEST
+2016-11-28 16:18:23.755 (+01:00)	e6e64a4e-b57d-11e6-9eee-0340b40f6d48	Your cron function "scheduled-cron-example-dev-cron" ran at Mon Nov 28 2016 15:18:23 GMT+0000 (UTC)
+END RequestId: e6e64a4e-b57d-11e6-9eee-0340b40f6d48
+REPORT RequestId: e6e64a4e-b57d-11e6-9eee-0340b40f6d48	Duration: 4.01 ms	Billed Duration: 100 ms 	Memory Size: 1024 MB	Max Memory Used: 16 MB
+
+START RequestId: 0a770e6f-b57e-11e6-ba68-f188460981c7 Version: $LATEST
+2016-11-28 16:19:22.921 (+01:00)	0a770e6f-b57e-11e6-ba68-f188460981c7	Your cron function "scheduled-cron-example-dev-cron" ran at Mon Nov 28 2016 15:19:22 GMT+0000 (UTC)
+END RequestId: 0a770e6f-b57e-11e6-ba68-f188460981c7
+REPORT RequestId: 0a770e6f-b57e-11e6-ba68-f188460981c7	Duration: 0.69 ms	Billed Duration: 100 ms 	Memory Size: 1024 MB	Max Memory Used: 16 MB
+```
+
+Since this only shows you the logs of the first cron job simply change the function name and run the command again:
+
+```bash
+serverless logs --function secondCron --tail
 ```
 
 ## Additonal Resources

--- a/aws-node-scheduled-cron/README.md
+++ b/aws-node-scheduled-cron/README.md
@@ -14,6 +14,8 @@ rate(value unit)
 
 `unit` - The unit of time. ( minute | minutes | hour | hours | day | days )
 
+**Example** `rate(5 minutes)`
+
 For more [information on the rate syntax see the AWS docs](http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions)
 
 ## Cron syntax

--- a/aws-node-scheduled-cron/README.md
+++ b/aws-node-scheduled-cron/README.md
@@ -99,6 +99,7 @@ Since this only shows you the logs of the first cron job simply change the funct
 serverless logs --function secondCron --tail
 ```
 
+
 ## Additonal Resources
 
 For more information on running cron with Serverless check out the [Tutorial: Serverless Scheduled Tasks](https://parall.ax/blog/view/3202/tutorial-serverless-scheduled-tasks) by Parallax.

--- a/aws-node-scheduled-cron/README.md
+++ b/aws-node-scheduled-cron/README.md
@@ -42,7 +42,7 @@ Read the [AWS cron expression syntax](http://docs.aws.amazon.com/lambda/latest/d
 To see your cron job running tail your logs with:
 
 ```bash
-serverless logs -function cron -tail
+serverless logs --function cron --tail
 ```
 
 ## Additonal Resources

--- a/aws-node-scheduled-cron/handler.js
+++ b/aws-node-scheduled-cron/handler.js
@@ -1,0 +1,5 @@
+
+module.exports.run = () => {
+  const time = new Date();
+  console.log(`Your cron ran ${time}`); // eslint-disable-line no-console
+};

--- a/aws-node-scheduled-cron/handler.js
+++ b/aws-node-scheduled-cron/handler.js
@@ -1,5 +1,6 @@
+'use strict';
 
-module.exports.run = () => {
+module.exports.run = (event, context) => {
   const time = new Date();
-  console.log(`Your cron ran ${time}`); // eslint-disable-line no-console
+  console.log(`Your cron function "${context.functionName}" ran at ${time}`); // eslint-disable-line no-console
 };

--- a/aws-node-scheduled-cron/serverless.yml
+++ b/aws-node-scheduled-cron/serverless.yml
@@ -8,4 +8,10 @@ functions:
   cron:
     handler: handler.run
     events:
+      # Invoke Lambda function every minute
       - schedule: rate(1 minute)
+  secondCron:
+    handler: handler.run
+    events:
+      # Invoke Lambda function every 2nd minute from Mon-Fri
+      - schedule: cron(0/2 * ? * MON-FRI *)

--- a/aws-node-scheduled-cron/serverless.yml
+++ b/aws-node-scheduled-cron/serverless.yml
@@ -1,0 +1,11 @@
+service: scheduled-cron-example
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  cron:
+    handler: handler.run
+    events:
+      - schedule: rate(1 minute)


### PR DESCRIPTION
Going to move over the examples from `serverless/serverless/docs` to this repo.

I'm working on a way to pull these into the site