### PR TITLE
Adding a CloudWatch RDS Custom Metric gatherer

### DIFF
--- a/community-examples.json
+++ b/community-examples.json
@@ -126,6 +126,11 @@
     "name": "keboola-developer-portal",
     "description": "Keboola developer portal built with Serverless",
     "githubUrl": "https://github.com/keboola/developer-portal"
-  }
+  },
+  {
+    "name": "serverless-cloudwatch-rds-custom-metrics",
+    "description": "A NodeJS-based MySQL RDS Data Collection script to push Custom Metrics to Cloudwatch with Serverless",
+    "githubUrl": "https://github.com/AndrewFarley/serverless-cloudwatch-rds-custom-metrics"
+  }  
 ]
 


### PR DESCRIPTION
Adding a tutorial/sample project I created.  This collects custom metric data from an RDS server in a VPC and push those custom metrics into cloudwatch metrics.  This was done to work with a bare-bones environment without a NAT Gateway using chained Lambdas.