### PR TITLE
change from put to update

### DIFF
--- a/aws-node-rest-api-with-dynamodb/todos/update.js
+++ b/aws-node-rest-api-with-dynamodb/todos/update.js
@@ -18,21 +18,21 @@ module.exports.update = (event, context, callback) => {
   const params = {
     TableName: 'todos',
     Key: {
-      id: event.pathParameters.id
+      id: event.pathParameters.id,
     },
     ExpressionAttributeNames: {
       '#c1': 'createdAt',
       '#c2': 'updatedAt',
       '#c3': 'text',
-      '#c4': 'checked'
+      '#c4': 'checked',
     },
     ExpressionAttributeValues: {
       ':d2': timestamp,
       ':d3': data.text,
-      ':d4': data.checked
+      ':d4': data.checked,
     },
     UpdateExpression: 'SET #c1 = if_not_exists(#c1, :d2), #c2 = :d2, #c3 = :d3, #c4 = :d4',
-    ReturnValues: 'ALL_NEW'
+    ReturnValues: 'ALL_NEW',
   };
 
   // update the todo in the database

--- a/aws-node-rest-api-with-dynamodb/todos/update.js
+++ b/aws-node-rest-api-with-dynamodb/todos/update.js
@@ -9,34 +9,24 @@ module.exports.update = (event, context, callback) => {
   const data = JSON.parse(event.body);
 
   // validation
-  if (typeof data.text !== 'string' || typeof data.checked !== 'boolean') {
+  if (typeof data.text !== 'string' && typeof data.checked !== 'boolean') {
     console.error('Validation Failed'); // eslint-disable-line no-console
     callback(new Error('Couldn\'t create the todo item.'));
     return;
   }
 
-const params = {
+  const params = {
     TableName: 'todos',
-	Key: {
-		id: event.pathParameters.id
-	},
-	ExpressionAttributeNames: {
-		"#c1": "createdAt",
-		"#c2": "updatedAt",
-		"#c3": "text",
-		"#c4": "checked"
-	},
-	ExpressionAttributeValues: {
-		":d2": timestamp,
-		":d3": data.text,
-		":d4": data.checked
-	},
-	UpdateExpression: "SET #c1 = if_not_exists(#c1, :d2), #c2 = :d2, #c3 = :d3, #c4 = :d4",
-	ReturnValues: "ALL_NEW"
-};
+    Item: {
+      id: event.pathParameters.id,
+      text: data.text,
+      checked: data.checked,
+      updatedAt: timestamp,
+    },
+  };
 
   // update the todo in the database
-  dynamoDb.update(params, (error, result) => {
+  dynamoDb.put(params, (error, result) => {
     // handle potential errors
     if (error) {
       console.error(error); // eslint-disable-line no-console
@@ -47,7 +37,7 @@ const params = {
     // create a resonse
     const response = {
       statusCode: 200,
-      body: JSON.stringify(result.Attributes),
+      body: JSON.stringify(result.Item),
     };
     callback(null, response);
   });

--- a/aws-node-rest-api-with-dynamodb/todos/update.js
+++ b/aws-node-rest-api-with-dynamodb/todos/update.js
@@ -9,24 +9,34 @@ module.exports.update = (event, context, callback) => {
   const data = JSON.parse(event.body);
 
   // validation
-  if (typeof data.text !== 'string' && typeof data.checked !== 'boolean') {
+  if (typeof data.text !== 'string' || typeof data.checked !== 'boolean') {
     console.error('Validation Failed'); // eslint-disable-line no-console
     callback(new Error('Couldn\'t create the todo item.'));
     return;
   }
 
-  const params = {
+const params = {
     TableName: 'todos',
-    Item: {
-      id: event.pathParameters.id,
-      text: data.text,
-      checked: data.checked,
-      updatedAt: timestamp,
-    },
-  };
+	Key: {
+		id: event.pathParameters.id
+	},
+	ExpressionAttributeNames: {
+		"#c1": "createdAt",
+		"#c2": "updatedAt",
+		"#c3": "text",
+		"#c4": "checked"
+	},
+	ExpressionAttributeValues: {
+		":d2": timestamp,
+		":d3": data.text,
+		":d4": data.checked
+	},
+	UpdateExpression: "SET #c1 = if_not_exists(#c1, :d2), #c2 = :d2, #c3 = :d3, #c4 = :d4",
+	ReturnValues: "ALL_NEW"
+};
 
   // update the todo in the database
-  dynamoDb.put(params, (error, result) => {
+  dynamoDb.update(params, (error, result) => {
     // handle potential errors
     if (error) {
       console.error(error); // eslint-disable-line no-console
@@ -37,7 +47,7 @@ module.exports.update = (event, context, callback) => {
     // create a resonse
     const response = {
       statusCode: 200,
-      body: JSON.stringify(result.Item),
+      body: JSON.stringify(result.Attributes),
     };
     callback(null, response);
   });

--- a/aws-node-rest-api-with-dynamodb/todos/update.js
+++ b/aws-node-rest-api-with-dynamodb/todos/update.js
@@ -21,18 +21,18 @@ module.exports.update = (event, context, callback) => {
       id: event.pathParameters.id
     },
     ExpressionAttributeNames: {
-      "#c1": "createdAt",
-      "#c2": "updatedAt",
-      "#c3": "text",
-      "#c4": "checked"
+      '#c1': 'createdAt',
+      '#c2': 'updatedAt',
+      '#c3': 'text',
+      '#c4': 'checked'
     },
     ExpressionAttributeValues: {
-      ":d2": timestamp,
-      ":d3": data.text,
-      ":d4": data.checked
+      ':d2': timestamp,
+      ':d3': data.text,
+      ':d4': data.checked
     },
-    UpdateExpression: "SET #c1 = if_not_exists(#c1, :d2), #c2 = :d2, #c3 = :d3, #c4 = :d4",
-    ReturnValues: "ALL_NEW"
+    UpdateExpression: 'SET #c1 = if_not_exists(#c1, :d2), #c2 = :d2, #c3 = :d3, #c4 = :d4',
+    ReturnValues: 'ALL_NEW'
   };
 
   // update the todo in the database


### PR DESCRIPTION
put is not the best option to explain DynamoDB Item update. In the earlier example, the attributes that are not updated, like createdAt will be lost, as put writes the entire new document (and the current example does not include the createdAt attribute), resulting in the attributes not supplied in the put being lost. Also updated the validation condition from AND (&&) to OR (||)

<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->