### PR TITLE
Add babel-cli dependency to Babel example

### DIFF
--- a/aws-node-function-compiled-with-babel/package.json
+++ b/aws-node-function-compiled-with-babel/package.json
@@ -6,6 +6,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "babel-cli": "~6.18.0",
     "babel-preset-latest": "^6.16.0",
     "serverless-babel-plugin": "^0.1.3"
   },


### PR DESCRIPTION
I was getting an error after installing the dependencies from NPM and running `serverless deploy`:
```
$ sls deploy -v
Serverless: Packaging service...
/Users/cmoel/Desktop/sls-babel/node_modules/serverless-babel-plugin/index.js:56
        const stdout = result.stdout.toString();
                                    ^

TypeError: Cannot read property 'toString' of null
```
(Full stacktrace: https://gist.github.com/cmoel/3707297a818f4eb79b186ac4e120e419.)

I found this was related to not having the `babel` executable available in `node_modules/.bin/` ( https://github.com/serverless/serverless-babel-plugin/blob/master/index.js#L55). Installing `babel-cli` fixed this issue for me.