### PR TITLE
Remove extra comma in provider request

### DIFF
--- a/aws-node-single-page-app-via-cloudfront/serverless-single-page-app-plugin/index.js
+++ b/aws-node-single-page-app-via-cloudfront/serverless-single-page-app-plugin/index.js
@@ -60,7 +60,7 @@ class ServerlessPlugin {
         'describeStacks',
         { StackName: stackName },
         this.options.stage,
-        this.options.region,
+        this.options.region
       )
       .then((result) => {
         const outputs = result.Stacks[0].Outputs;


### PR DESCRIPTION
At line 63 in the single page app plugin, there was an extra comma that was resulting in an error when running serverless operations.