### PR TITLE
Lock down permissions to a specific table

### DIFF
--- a/aws-node-rest-api-with-dynamodb/serverless.yml
+++ b/aws-node-rest-api-with-dynamodb/serverless.yml
@@ -16,13 +16,7 @@ provider:
         - dynamodb:PutItem
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
-      Resource:
-        Fn::Join:
-          - ""
-          - - "arn:aws:dynamodb:"
-            - ${self:provider.region}
-            - ":*:table/"
-            - ${self:service}-${opt:stage, self:provider.stage}
+      Resource: "arn:aws:dynamodb:${self:provider.region}:*:table/${env:DYNAMODB_TABLE}"
 
 functions:
   create:
@@ -82,4 +76,4 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
-        TableName: ${self:service}-${opt:stage, self:provider.stage}
+        TableName: ${env:DYNAMODB_TABLE}

--- a/aws-node-rest-api-with-dynamodb/serverless.yml
+++ b/aws-node-rest-api-with-dynamodb/serverless.yml
@@ -8,14 +8,19 @@ provider:
   iamRoleStatements:
     - Effect: Allow
       Action:
-        - dynamodb:DescribeTable
         - dynamodb:Query
         - dynamodb:Scan
         - dynamodb:GetItem
         - dynamodb:PutItem
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
-      Resource: "arn:aws:dynamodb:us-east-1:*:*"
+      Resource:
+        Fn::Join:
+          - ""
+          - - "arn:aws:dynamodb:"
+            - ${self:provider.region}
+            - ":*:table/"
+            - ${self:service}-${opt:stage, self:provider.stage}
 
 functions:
   create:
@@ -75,4 +80,4 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
-        TableName: 'todos'
+        TableName: ${self:service}-${opt:stage, self:provider.stage}

--- a/aws-node-rest-api-with-dynamodb/serverless.yml
+++ b/aws-node-rest-api-with-dynamodb/serverless.yml
@@ -5,6 +5,8 @@ frameworkVersion: ">=1.1.0 <2.0.0"
 provider:
   name: aws
   runtime: nodejs4.3
+  environment:
+    DYNAMODB_TABLE: ${self:service}-${opt:stage, self:provider.stage}
   iamRoleStatements:
     - Effect: Allow
       Action:

--- a/aws-node-rest-api-with-dynamodb/todos/create.js
+++ b/aws-node-rest-api-with-dynamodb/todos/create.js
@@ -15,7 +15,7 @@ module.exports.create = (event, context, callback) => {
   }
 
   const params = {
-    TableName: 'todos',
+    TableName: process.env.DYNAMODB_TABLE,
     Item: {
       id: uuid.v1(),
       text: data.text,

--- a/aws-node-rest-api-with-dynamodb/todos/delete.js
+++ b/aws-node-rest-api-with-dynamodb/todos/delete.js
@@ -6,7 +6,7 @@ const dynamoDb = new AWS.DynamoDB.DocumentClient();
 
 module.exports.delete = (event, context, callback) => {
   const params = {
-    TableName: 'todos',
+    TableName: process.env.DYNAMODB_TABLE,
     Key: {
       id: event.pathParameters.id,
     },

--- a/aws-node-rest-api-with-dynamodb/todos/get.js
+++ b/aws-node-rest-api-with-dynamodb/todos/get.js
@@ -6,7 +6,7 @@ const dynamoDb = new AWS.DynamoDB.DocumentClient();
 
 module.exports.get = (event, context, callback) => {
   const params = {
-    TableName: 'todos',
+    TableName: process.env.DYNAMODB_TABLE,
     Key: {
       id: event.pathParameters.id,
     },

--- a/aws-node-rest-api-with-dynamodb/todos/list.js
+++ b/aws-node-rest-api-with-dynamodb/todos/list.js
@@ -4,7 +4,7 @@ const AWS = require('aws-sdk');
 
 const dynamoDb = new AWS.DynamoDB.DocumentClient();
 const params = {
-  TableName: 'todos',
+  TableName: process.env.DYNAMODB_TABLE,
 };
 
 module.exports.list = (event, context, callback) => {

--- a/aws-node-rest-api-with-dynamodb/todos/update.js
+++ b/aws-node-rest-api-with-dynamodb/todos/update.js
@@ -16,7 +16,7 @@ module.exports.update = (event, context, callback) => {
   }
 
   const params = {
-    TableName: 'todos',
+    TableName: process.env.DYNAMODB_TABLE,
     Key: {
       id: event.pathParameters.id,
     },


### PR DESCRIPTION
Issue Ref: #49

---

This is simply to ensure that anyone copying and pasting this example won't accidentally open up access to every DynamoDB table of theirs in the us-east-1 region.

Assuming the following:

- Service Name: `serverless-rest-api-with-dynamodb`
- Region: `us-east-1`
- Stage: `dev`

This will create a DynamoDB resource with a table name of:
`serverless-rest-api-with-dynamodb-dev`

And provide access to an ARN of:
`arn:aws:dynamodb:us-east-1:*:table/serverless-rest-api-with-dynamodb-dev`