### PR TITLE
Passing auth0 client secret as string without base64 encoding #62

### DIFF
--- a/aws-node-auth0-custom-authorizers-api/handler.js
+++ b/aws-node-auth0-custom-authorizers-api/handler.js
@@ -29,7 +29,7 @@ module.exports.auth = (event, context, cb) => {
     const options = {
       audience: AUTH0_CLIENT_ID,
     };
-    jwt.verify(token, new Buffer(AUTH0_CLIENT_SECRET, 'base64'), options, (err, decoded) => {
+    jwt.verify(token, AUTH0_CLIENT_SECRET, options, (err, decoded) => {
       if (err) {
         cb('Unauthorized');
       } else {


### PR DESCRIPTION
Hey! This is a pull-request to solve an authorization issue caused by a change made by Auth0 to the `jsonwebtoken` package since december 2016.

@michieldewilde has opened an issue (Verify JWT Auth0 #62) about this - which confirms someone else is also experiencing the same problem.
Reference: https://auth0.com/forum/t/client-secret-stored-without-base64-encoding/4338/8