### PR TITLE
fix environment reference to DYNAMODB_TABLE

### DIFF
--- a/aws-node-rest-api-with-dynamodb/serverless.yml
+++ b/aws-node-rest-api-with-dynamodb/serverless.yml
@@ -16,7 +16,7 @@ provider:
         - dynamodb:PutItem
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
-      Resource: "arn:aws:dynamodb:${self:provider.region}:*:table/${env:DYNAMODB_TABLE}"
+      Resource: "arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.DYNAMODB_TABLE}"
 
 functions:
   create:
@@ -76,4 +76,4 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
-        TableName: ${env:DYNAMODB_TABLE}
+        TableName: ${self:provider.environment.DYNAMODB_TABLE}


### PR DESCRIPTION
Deploying the example fails as described in #70. Setting a custom table
name by setting DYNAMODB_TABLE in the environment will sucessfully
deploy, but the deployed code will fail at runtime, since it references
the wrong table name.

This fixes it by referencing the generated table name under
provider.environment.

fixes #70