### PR TITLE
remove aws-sdk from dependencies

### DIFF
--- a/aws-node-fetch-file-and-store-in-s3/handler.js
+++ b/aws-node-fetch-file-and-store-in-s3/handler.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const fetch = require('node-fetch');
-const AWS = require('aws-sdk');
+const AWS = require('aws-sdk'); // eslint-disable-line import/no-extraneous-dependencies
 AWS.config.setPromisesDependency(require('bluebird'));
 
 const s3 = new AWS.S3();

--- a/aws-node-fetch-file-and-store-in-s3/package.json
+++ b/aws-node-fetch-file-and-store-in-s3/package.json
@@ -5,7 +5,6 @@
   "author": "Bozhao Yu",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.7.9",
     "bluebird": "^3.4.6",
     "node-fetch": "^1.6.3"
   }

--- a/aws-node-rest-api-with-dynamodb/package.json
+++ b/aws-node-rest-api-with-dynamodb/package.json
@@ -5,7 +5,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.6.7",
     "uuid": "^2.0.3"
   }
 }

--- a/aws-node-rest-api-with-dynamodb/todos/create.js
+++ b/aws-node-rest-api-with-dynamodb/todos/create.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const uuid = require('uuid');
-const AWS = require('aws-sdk');
+const AWS = require('aws-sdk'); // eslint-disable-line import/no-extraneous-dependencies
 
 const dynamoDb = new AWS.DynamoDB.DocumentClient();
 

--- a/aws-node-rest-api-with-dynamodb/todos/delete.js
+++ b/aws-node-rest-api-with-dynamodb/todos/delete.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AWS = require('aws-sdk');
+const AWS = require('aws-sdk'); // eslint-disable-line import/no-extraneous-dependencies
 
 const dynamoDb = new AWS.DynamoDB.DocumentClient();
 

--- a/aws-node-rest-api-with-dynamodb/todos/get.js
+++ b/aws-node-rest-api-with-dynamodb/todos/get.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AWS = require('aws-sdk');
+const AWS = require('aws-sdk'); // eslint-disable-line import/no-extraneous-dependencies
 
 const dynamoDb = new AWS.DynamoDB.DocumentClient();
 

--- a/aws-node-rest-api-with-dynamodb/todos/list.js
+++ b/aws-node-rest-api-with-dynamodb/todos/list.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AWS = require('aws-sdk');
+const AWS = require('aws-sdk'); // eslint-disable-line import/no-extraneous-dependencies
 
 const dynamoDb = new AWS.DynamoDB.DocumentClient();
 const params = {

--- a/aws-node-rest-api-with-dynamodb/todos/update.js
+++ b/aws-node-rest-api-with-dynamodb/todos/update.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AWS = require('aws-sdk');
+const AWS = require('aws-sdk'); // eslint-disable-line import/no-extraneous-dependencies
 
 const dynamoDb = new AWS.DynamoDB.DocumentClient();
 

--- a/aws-node-text-analysis-via-sns-post-processing/addNote.js
+++ b/aws-node-text-analysis-via-sns-post-processing/addNote.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AWS = require('aws-sdk');
+const AWS = require('aws-sdk'); // eslint-disable-line import/no-extraneous-dependencies
 const config = require('./config.js');
 
 const sns = new AWS.SNS();

--- a/aws-node-text-analysis-via-sns-post-processing/package.json
+++ b/aws-node-text-analysis-via-sns-post-processing/package.json
@@ -5,7 +5,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.6.7",
     "sentiment": "^2.1.0"
   }
 }


### PR DESCRIPTION
aws-sdk is automatically included in the lambda context. Adding it is
unnecessary, and increases the size of the service .zip file by 2
magnitudes.

<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->