### PR TITLE
add offline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Have an example? Submit a PR or [open an issue](https://github.com/serverless/ex
 | [Aws Function Compiled With Babel](https://github.com/serverless/examples/tree/master/aws-node-function-compiled-with-babel) <br/> Demonstrating how to compile all your code with Babel | nodeJS |
 | [Aws Github Webhook Listener](https://github.com/serverless/examples/tree/master/aws-node-github-webhook-listener) <br/> Extend your github repositories with this github webhook listener | nodeJS |
 | [Aws Iot Event](https://github.com/serverless/examples/tree/master/aws-node-iot-event) <br/> Example on how to setup a AWS IoT Rule to send events to a Lambda function | nodeJS |
+| [Aws Rest Api Offline](https://github.com/serverless/examples/tree/master/aws-node-rest-api-offline) <br/> Serverless REST API with DynamoDB and offline support | nodeJS |
 | [Aws Rest With Dynamodb](https://github.com/serverless/examples/tree/master/aws-node-rest-api-with-dynamodb) <br/> Serverless CRUD service exposing a REST HTTP interface | nodeJS |
 | [Aws Scheduled Cron](https://github.com/serverless/examples/tree/master/aws-node-scheduled-cron) <br/> Example of creating a function that runs as a cron job using the serverless `schedule` event | nodeJS |
 | [Aws Scheduled Weather](https://github.com/serverless/examples/tree/master/aws-node-scheduled-weather) <br/> Example of creating a function that runs as a cron job using the serverless `schedule` event through pulling weather and sending an email daily. | nodeJS |

--- a/aws-node-rest-api-offline/.gitignore
+++ b/aws-node-rest-api-offline/.gitignore
@@ -1,0 +1,2 @@
+.serverless
+node_modules

--- a/aws-node-rest-api-offline/README.md
+++ b/aws-node-rest-api-offline/README.md
@@ -1,0 +1,82 @@
+# Serverless REST API with DynamoDB and offline support
+
+This example demonstrates how to run a service locally, using the
+[serverless-offline](https://github.com/dherault/serverless-offline) plugin. It
+provides a REST API to manage Todos stored in a DynamoDB, similar to the
+[aws-node-rest-api-with-dynamodb](https://github.com/serverless/examples/tree/master/aws-node-rest-api-with-dynamodb)
+example. A local DynamoDB instance is provided by the
+[serverless-dynamodb-local](https://github.com/99xt/serverless-dynamodb-local)
+plugin.
+
+## Use-case
+
+Test your service locally, without having to deploy it first.
+
+## Setup
+
+```bash
+npm install
+serverless dynamodb install
+```
+
+## Run service offline
+
+```bash
+serverless offline
+```
+
+## Usage
+
+You can create, retrieve, update, or delete todos with the following commands:
+
+### Create a Todo
+
+```bash
+curl -X POST -H "Content-Type:application/json" http://localhost:3000/todos --data '{ "text": "Learn Serverless" }'
+```
+
+No output
+
+### List all Todos
+
+```bash
+curl -H "Content-Type:application/json" http://localhost:3000/todos
+```
+
+Example output:
+```bash
+[{"text":"Deploy my first service","id":"ac90fe80-aa83-11e6-9ede-afdfa051af86","checked":true,"updatedAt":1479139961304},{"text":"Learn Serverless","id":"20679390-aa85-11e6-9ede-afdfa051af86","createdAt":1479139943241,"checked":false,"updatedAt":1479139943241}]%
+```
+
+### Get one Todo
+
+```bash
+# Replace the <id> part with a real id from your todos table
+curl -H "Content-Type:application/json" http://localhost:3000/todos/<id>
+```
+
+Example Result:
+```bash
+{"text":"Learn Serverless","id":"ee6490d0-aa81-11e6-9ede-afdfa051af86","createdAt":1479138570824,"checked":false,"updatedAt":1479138570824}%
+```
+
+### Update a Todo
+
+```bash
+# Replace the <id> part with a real id from your todos table
+curl -X PUT -H "Content-Type:application/json" http://localhost:3000/todos/<id> --data '{ "text": "Learn Serverless", "checked": true }'
+```
+
+Example Result:
+```bash
+{"text":"Learn Serverless","id":"ee6490d0-aa81-11e6-9ede-afdfa051af86","createdAt":1479138570824,"checked":true,"updatedAt":1479138570824}%
+```
+
+### Delete a Todo
+
+```bash
+# Replace the <id> part with a real id from your todos table
+curl -X DELETE -H "Content-Type:application/json" http://localhost:3000/todos/<id>
+```
+
+No output

--- a/aws-node-rest-api-offline/offline/migrations/todos.json
+++ b/aws-node-rest-api-offline/offline/migrations/todos.json
@@ -1,0 +1,21 @@
+{
+    "Table": {
+        "TableName": "serverless-rest-api-with-dynamodb-dev",
+        "KeySchema": [
+            {
+                "AttributeName": "id",
+                "KeyType": "HASH"
+            }
+        ],
+        "AttributeDefinitions": [
+            {
+                "AttributeName": "id",
+                "AttributeType": "S"
+            }
+        ],
+        "ProvisionedThroughput": {
+            "ReadCapacityUnits": 1,
+            "WriteCapacityUnits": 1
+        }
+    }
+}

--- a/aws-node-rest-api-offline/package.json
+++ b/aws-node-rest-api-offline/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "aws-rest-api-offline",
+  "version": "1.0.0",
+  "description": "Serverless REST API with DynamoDB and offline support",
+  "repository": "",
+  "author": "Christoph Gysin <christoph.gysin@gmail.com>",
+  "license": "MIT",
+  "dependencies": {
+    "aws-sdk": "^2.12.0",
+    "serverless-dynamodb-local": "^0.2.18",
+    "serverless-offline": "^3.8.3",
+    "uuid": "^2.0.3"
+  }
+}

--- a/aws-node-rest-api-offline/serverless.yml
+++ b/aws-node-rest-api-offline/serverless.yml
@@ -1,0 +1,92 @@
+service: serverless-rest-api-with-dynamodb
+
+frameworkVersion: ">=1.1.0 <2.0.0"
+
+plugins:
+  - serverless-dynamodb-local
+  - serverless-offline
+
+custom:
+  dynamodb:
+    start:
+      port: 8000
+      inMemory: true
+      migration: true
+    migration:
+      dir: offline/migrations
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+  environment:
+    DYNAMODB_TABLE: ${self:service}-${opt:stage, self:provider.stage}
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - dynamodb:Query
+        - dynamodb:Scan
+        - dynamodb:GetItem
+        - dynamodb:PutItem
+        - dynamodb:UpdateItem
+        - dynamodb:DeleteItem
+      Resource: "arn:aws:dynamodb:${opt:region, self:provider.region}:*:table/${self:provider.environment.DYNAMODB_TABLE}"
+
+functions:
+  create:
+    handler: todos/create.create
+    events:
+      - http:
+          path: todos
+          method: post
+          cors: true
+
+  list:
+    handler: todos/list.list
+    events:
+      - http:
+          path: todos
+          method: get
+          cors: true
+
+  get:
+    handler: todos/get.get
+    events:
+      - http:
+          path: todos/{id}
+          method: get
+          cors: true
+
+  update:
+    handler: todos/update.update
+    events:
+      - http:
+          path: todos/{id}
+          method: put
+          cors: true
+
+  delete:
+    handler: todos/delete.delete
+    events:
+      - http:
+          path: todos/{id}
+          method: delete
+          cors: true
+
+resources:
+  Resources:
+    TodosDynamoDbTable:
+      Type: 'AWS::DynamoDB::Table'
+      DeletionPolicy: Retain
+      Properties:
+        AttributeDefinitions:
+          -
+            AttributeName: id
+            AttributeType: S
+        KeySchema:
+          -
+            AttributeName: id
+            KeyType: HASH
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1
+        TableName: ${self:provider.environment.DYNAMODB_TABLE}

--- a/aws-node-rest-api-offline/todos/create.js
+++ b/aws-node-rest-api-offline/todos/create.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const uuid = require('uuid');
+const dynamodb = require('./dynamodb');
+
+module.exports.create = (event, context, callback) => {
+  const timestamp = new Date().getTime();
+  const data = JSON.parse(event.body);
+  if (typeof data.text !== 'string') {
+    console.error('Validation Failed');
+    callback(new Error('Couldn\'t create the todo item.'));
+    return;
+  }
+
+  const params = {
+    TableName: process.env.DYNAMODB_TABLE,
+    Item: {
+      id: uuid.v1(),
+      text: data.text,
+      checked: false,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+  };
+
+  // write the todo to the database
+  dynamodb.put(params, (error, result) => {
+    // handle potential errors
+    if (error) {
+      console.error(error);
+      callback(new Error('Couldn\'t create the todo item.'));
+      return;
+    }
+
+    // create a response
+    const response = {
+      statusCode: 200,
+      body: JSON.stringify(result.Item),
+    };
+    callback(null, response);
+  });
+};

--- a/aws-node-rest-api-offline/todos/delete.js
+++ b/aws-node-rest-api-offline/todos/delete.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const dynamodb = require('./dynamodb');
+
+module.exports.delete = (event, context, callback) => {
+  const params = {
+    TableName: process.env.DYNAMODB_TABLE,
+    Key: {
+      id: event.pathParameters.id,
+    },
+  };
+
+  // delete the todo from the database
+  dynamodb.delete(params, (error) => {
+    // handle potential errors
+    if (error) {
+      console.error(error);
+      callback(new Error('Couldn\'t remove the todo item.'));
+      return;
+    }
+
+    // create a response
+    const response = {
+      statusCode: 200,
+      body: JSON.stringify({}),
+    };
+    callback(null, response);
+  });
+};

--- a/aws-node-rest-api-offline/todos/dynamodb.js
+++ b/aws-node-rest-api-offline/todos/dynamodb.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const AWS = require('aws-sdk'); // eslint-disable-line import/no-extraneous-dependencies
+
+let options = {};
+
+// connect to local DB if running offline
+if (process.env.IS_OFFLINE) {
+  options = {
+    region: 'localhost',
+    endpoint: 'http://localhost:8000',
+  };
+}
+
+const client = new AWS.DynamoDB.DocumentClient(options);
+
+module.exports = client;

--- a/aws-node-rest-api-offline/todos/get.js
+++ b/aws-node-rest-api-offline/todos/get.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const dynamodb = require('./dynamodb');
+
+module.exports.get = (event, context, callback) => {
+  const params = {
+    TableName: process.env.DYNAMODB_TABLE,
+    Key: {
+      id: event.pathParameters.id,
+    },
+  };
+
+  // fetch todo from the database
+  dynamodb.get(params, (error, result) => {
+    // handle potential errors
+    if (error) {
+      console.error(error);
+      callback(new Error('Couldn\'t fetch the todo item.'));
+      return;
+    }
+
+    // create a response
+    const response = {
+      statusCode: 200,
+      body: JSON.stringify(result.Item),
+    };
+    callback(null, response);
+  });
+};

--- a/aws-node-rest-api-offline/todos/list.js
+++ b/aws-node-rest-api-offline/todos/list.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const dynamodb = require('./dynamodb');
+
+module.exports.list = (event, context, callback) => {
+  const params = {
+    TableName: process.env.DYNAMODB_TABLE,
+  };
+
+  // fetch all todos from the database
+  dynamodb.scan(params, (error, result) => {
+    // handle potential errors
+    if (error) {
+      console.error(error);
+      callback(new Error('Couldn\'t fetch the todos.'));
+      return;
+    }
+
+    // create a response
+    const response = {
+      statusCode: 200,
+      body: JSON.stringify(result.Items),
+    };
+    callback(null, response);
+  });
+};

--- a/aws-node-rest-api-offline/todos/update.js
+++ b/aws-node-rest-api-offline/todos/update.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const dynamodb = require('./dynamodb');
+
+module.exports.update = (event, context, callback) => {
+  const timestamp = new Date().getTime();
+  const data = JSON.parse(event.body);
+
+  // validation
+  if (typeof data.text !== 'string' || typeof data.checked !== 'boolean') {
+    console.error('Validation Failed');
+    callback(new Error('Couldn\'t update the todo item.'));
+    return;
+  }
+
+  const params = {
+    TableName: process.env.DYNAMODB_TABLE,
+    Key: {
+      id: event.pathParameters.id,
+    },
+    ExpressionAttributeNames: {
+      '#todo_text': 'text',
+    },
+    ExpressionAttributeValues: {
+      ':text': data.text,
+      ':checked': data.checked,
+      ':updatedAt': timestamp,
+    },
+    UpdateExpression: 'SET #todo_text = :text, checked = :checked, updatedAt = :updatedAt',
+    ReturnValues: 'ALL_NEW',
+  };
+
+  // update the todo in the database
+  dynamodb.update(params, (error, result) => {
+    // handle potential errors
+    if (error) {
+      console.error(error);
+      callback(new Error('Couldn\'t update the todo item.'));
+      return;
+    }
+
+    // create a response
+    const response = {
+      statusCode: 200,
+      body: JSON.stringify(result.Attributes),
+    };
+    callback(null, response);
+  });
+};


### PR DESCRIPTION
This adds an example identical to aws-node-rest-api-with-dynamodb, but
with the ability to run it offline using the plugins serverless-offline
and serverless-dynamodb-local.

fixes #14

<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->