### PR TITLE
aws-node-fetch-file-and-store-in-s3: lock down permissions

### DIFF
--- a/aws-node-fetch-file-and-store-in-s3/serverless.yml
+++ b/aws-node-fetch-file-and-store-in-s3/serverless.yml
@@ -13,8 +13,8 @@ provider:
   iamRoleStatements:
     - Effect: Allow
       Action:
-        - s3:*
-      Resource: "*"
+        - s3:PutObject
+      Resource: "arn:aws:s3:::${self:custom.bucket}/*"
 
 functions:
   save:


### PR DESCRIPTION
Only allow to create objects in specific bucket.

part of #49

<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->