### PR TITLE
Add yunspace/serverless-golang to community examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ A collection of ready-to-deploy [Serverless Framework](https://github.com/server
 <!-- ⛔️ AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click to expand) generated w/ `npm run docs`  -->
 <details>
 <summary>Click to expand</summary>
+
 - [Getting Started](#getting-started)
 - [Examples](#examples)
 - [Community Examples](#community-examples)
 - [Contributing](#contributing)
   * [Adding example code](#adding-example-code)
   * [Adding a community example](#adding-a-community-example)
+
 </details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
@@ -72,9 +74,14 @@ Have an example? Submit a PR or [open an issue](https://github.com/serverless/ex
 
 [Add an example](https://github.com/serverless/examples/edit/master/community-examples.json)
 
+To install any of these you can run:
+
+    serverless install -u https://github.com/author/project -n my-project
+
 <!-- AUTO-GENERATED-CONTENT:START (COMMUNITY_EXAMPLES_TABLE)  generated w/ `npm run docs` -->
 | Example | Author |
 |:-------|:------:|
+| **[Aws Api Gateway Serverless Project Written In Go](https://github.com/yunspace/serverless-golang)** <br/> A serverless project that contains an API Gateway endpoint powered by a Lambda function written in golang and built using [eawsy/aws-lambda-go-shim](https://github.com/eawsy/aws-lambda-go-shim). | [yunspace](http://github.com/yunspace) |
 | **[Serverless Reactjs Universal Rendering Boilerplate](http://github.com/TylorShin/react-universal-in-serverless)** <br/> ReactJS web app Starter kit does universal (isomorphic) rendering with Serverless | [TylorShin](http://github.com/TylorShin) |
 | **[Adoptable Pet Bot](https://github.com/lynnaloo/adoptable-pet-bot)** <br/> Tweets adoptable pets using Serverless (Node.js) and AWS Lambda | [lynnaloo](http://github.com/lynnaloo) |
 | **[Bittman](https://github.com/rhlsthrm/bittman)** <br/> A serverless project that follows a stock trading algorithm and uses scheduled functions to save data to DynamoDB and send emails through Mailgun. | [rhlsthrm](http://github.com/rhlsthrm) |

--- a/community-examples.json
+++ b/community-examples.json
@@ -197,5 +197,10 @@
     "name": "Serverless ReactJS Universal Rendering Boilerplate",
     "description": "ReactJS web app Starter kit does universal (isomorphic) rendering with Serverless",
     "githubUrl": "http://github.com/TylorShin/react-universal-in-serverless"
+  },
+  {
+    "name": "AWS API Gateway Serverless project written in Go",
+    "description": "A serverless project that contains an API Gateway endpoint powered by a Lambda function written in golang and built using [eawsy/aws-lambda-go-shim](https://github.com/eawsy/aws-lambda-go-shim).",
+    "githubUrl": "https://github.com/yunspace/serverless-golang"
   }
 ]


### PR DESCRIPTION
An example of a serverless project written in golang using https://github.com/eawsy/aws-lambda-go-shim
In addition it reminds users how to locally install any such community project.

This is likely enough to fix the following issues:
- https://github.com/yunspace/serverless-golang/issues/5
- https://github.com/serverless/serverless/issues/2712