### PR TITLE
fix(param): replace migration with migrate

### DIFF
--- a/aws-node-rest-api-with-dynamodb-and-offline/serverless.yml
+++ b/aws-node-rest-api-with-dynamodb-and-offline/serverless.yml
@@ -11,7 +11,7 @@ custom:
     start:
       port: 8000
       inMemory: true
-      migration: true
+      migrate: true
     migration:
       dir: offline/migrations
 


### PR DESCRIPTION
fix(param): replace migration with migrate

The plugin doesn't migrate on start.