### PR TITLE
OpenWhisk examples for non-Node.js runtimes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,18 @@ Have an example? Submit a PR or [open an issue](https://github.com/serverless/ex
 | [Aws Simple Http Endpoint](https://github.com/serverless/examples/tree/master/aws-python-simple-http-endpoint) <br/> Example demonstrates how to setup a simple HTTP GET endpoint with python | python |
 | [Azure Node Simple Http Endpoint](https://github.com/serverless/examples/tree/master/azure-node-simple-http-endpoint) <br/> An example of making http endpoints with the Azure Functions Serverless Framework plugin | nodeJS |
 | [Google Node Simple Http Endpoint](https://github.com/serverless/examples/tree/master/google-node-simple-http-endpoint) <br/> An example of making http endpoints with the Google Cloud Functions Serverless Framework plugin. | nodeJS |
+| [Openwhisk Go Simple](https://github.com/serverless/examples/tree/master/openwhisk-go-simple) <br/> Example demonstrates how to setup a simple Go function with OpenWhisk. | nodeJS |
+| [Openwhisk Node And Docker Chaining Functions](https://github.com/serverless/examples/tree/master/openwhisk-node-and-docker-chaining-functions) <br/> Example of chaining function calls using sequences and docker images. | nodeJS |
 | [Openwhisk Node Chaining Functions](https://github.com/serverless/examples/tree/master/openwhisk-node-chaining-functions) <br/> Example of chaining function calls using sequences and the sdk. | nodeJS |
 | [Openwhisk Node Scheduled Cron](https://github.com/serverless/examples/tree/master/openwhisk-node-scheduled-cron) <br/> Example of creating a function that runs as a cron job using the serverless schedule event. | nodeJS |
 | [Openwhisk Node Simple Http](https://github.com/serverless/examples/tree/master/openwhisk-node-simple-http-endpoint) <br/> Example demonstrates how to setup a simple HTTP GET endpoint with OpenWhisk. | nodeJS |
 | [Openwhisk Node Simple](https://github.com/serverless/examples/tree/master/openwhisk-node-simple) <br/> Simple example demonstrating OpenWhisk provider support. | nodeJS |
+| [Openwhisk Python Scheduled Cron](https://github.com/serverless/examples/tree/master/openwhisk-python-scheduled-cron) <br/> Example of creating a Python function that runs as a cron job using the serverless schedule event. | python |
+| [Openwhisk Python Simple Http Endpoint](https://github.com/serverless/examples/tree/master/openwhisk-python-simple-http-endpoint) <br/> Example demonstrates how to setup a simple HTTP GET endpoint with OpenWhisk. | python |
+| [Openwhisk Python Simple](https://github.com/serverless/examples/tree/master/openwhisk-python-simple) <br/> Example demonstrates how to setup a simple Python function with OpenWhisk. | python |
+| [Openwhisk Swift Scheduled Cron](https://github.com/serverless/examples/tree/master/openwhisk-swift-scheduled-cron) <br/> Example of creating a Swift function that runs as a cron job using the serverless schedule event. | nodeJS |
+| [Openwhisk Swift Simple Http Endpoint](https://github.com/serverless/examples/tree/master/openwhisk-swift-simple-http-endpoint) <br/> Example demonstrates how to setup a simple HTTP endpoint using Swift function with OpenWhisk. | nodeJS |
+| [Openwhisk Swift Simple](https://github.com/serverless/examples/tree/master/openwhisk-swift-simple) <br/> Example demonstrates how to setup a simple Swift function with OpenWhisk. | nodeJS |
 
 <!-- AUTO-GENERATED-CONTENT:END -->
 

--- a/openwhisk-go-simple/.gitignore
+++ b/openwhisk-go-simple/.gitignore
@@ -1,0 +1,3 @@
+.serverless
+*.pyc
+*.pyo

--- a/openwhisk-go-simple/README.md
+++ b/openwhisk-go-simple/README.md
@@ -1,0 +1,58 @@
+# Serverless Boilerplate - OpenWhisk - Go
+
+Make sure `serverless` is installed. [See installation guide](https://serverless.com/framework/docs/providers/openwhisk/guide/installation/).
+
+You will also need to set up your OpenWhisk account credentials using environment variables or a configuration file. Please see the [this guide for more information](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).
+
+## 1. Install Provider Plugin
+`npm install -g serverless-openwhisk` 
+
+## 2. Install Service Dependencies
+`npm install` in this directory to download the modules from `package.json`.
+
+## 3. Compile Go Binary
+
+```
+$ env GOOS=linux GOARCH=amd64 go build handler.go
+```
+
+## 3. Deploy
+`serverless deploy` or `sls deploy`. `sls` is shorthand for the Serverless CLI command
+
+```
+Serverless: Packaging service...
+Serverless: Compiling Functions...
+Serverless: Compiling API Gateway definitions...
+Serverless: Compiling Rules...
+Serverless: Compiling Triggers & Feeds...
+Serverless: Deploying Functions...
+Serverless: Deployment successful!
+
+Service Information
+platform:	openwhisk.ng.bluemix.net
+namespace:	_
+service:	go-service
+
+actions:
+go-service-dev-greeting
+```
+
+## 4. Invoke deployed function
+`serverless invoke --function greeting` or `serverless invoke -f greeting`
+
+`-f` is shorthand for `--function`
+
+In your terminal window you should see the response from Apache OpenWhisk
+
+```bash
+$ serverless invoke -f greeting
+{
+    "msg": "Hello stranger!"
+}
+$ serverless invoke -f greeting -d '{"name": "James"}'
+{
+    "msg": "Hello James!"
+}
+```
+
+**For more information on the Serverless OpenWhisk plugin, please see the project repository: [https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).**

--- a/openwhisk-go-simple/handler.go
+++ b/openwhisk-go-simple/handler.go
@@ -1,0 +1,21 @@
+package main
+
+import "encoding/json"
+import "fmt"
+import "os"
+
+func main() {
+	// native actions receive one argument, the JSON object as a string
+	arg := os.Args[1]
+
+	// unmarshal the string to a JSON object
+	var obj map[string]interface{}
+	json.Unmarshal([]byte(arg), &obj)
+	name, ok := obj["name"].(string)
+	if !ok {
+		name = "Stranger"
+	}
+	msg := map[string]string{"msg": ("Hello, " + name + "!")}
+	res, _ := json.Marshal(msg)
+	fmt.Println(string(res))
+}

--- a/openwhisk-go-simple/package.json
+++ b/openwhisk-go-simple/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openwhisk-go-simple",
+  "version": "0.1.0",
+  "description": "Example demonstrates how to setup a simple Go function with OpenWhisk.",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/openwhisk-go-simple/serverless.yml
+++ b/openwhisk-go-simple/serverless.yml
@@ -1,0 +1,12 @@
+service: go-service
+
+provider:
+  name: openwhisk
+  runtime: binary 
+
+functions:
+  greeting:
+    handler: handler
+
+plugins:
+  - serverless-openwhisk

--- a/openwhisk-node-and-docker-chaining-functions/.gitignore
+++ b/openwhisk-node-and-docker-chaining-functions/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.serverless

--- a/openwhisk-node-and-docker-chaining-functions/README.md
+++ b/openwhisk-node-and-docker-chaining-functions/README.md
@@ -1,0 +1,61 @@
+# Serverless Boilerplate - OpenWhisk - Node.js & Docker
+
+Make sure `serverless` is installed. [See installation guide](https://serverless.com/framework/docs/providers/openwhisk/guide/installation/).
+
+You will also need to set up your OpenWhisk account credentials using environment variables or a configuration file. Please see the [this guide for more information](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).
+
+## 1. Install Provider Plugin
+`npm install -g serverless-openwhisk` 
+
+## 2. Install Service Dependencies
+`npm install` in this directory to download the modules from `package.json`.
+
+## 3. Deploy
+`serverless deploy` or `sls deploy`. `sls` is shorthand for the Serverless CLI command
+
+```
+$ serverless deploy
+Serverless: Packaging service...
+Serverless: Compiling Functions...
+Serverless: Compiling API Gateway definitions...
+Serverless: Compiling Rules...
+Serverless: Compiling Triggers & Feeds...
+Serverless: Deploying Functions...
+Serverless: Deploying Sequences...
+Serverless: Deployment successful!
+
+Service Information
+platform:	openwhisk.ng.bluemix.net
+namespace:	_
+service:	testing
+
+actions:
+testing-dev-location_sunrise_sunset    testing-dev-sunrise_sunset    testing-dev-location_from_address    testing-dev-jq
+```
+
+## 4. Invoke sequence function
+`serverless invoke -f location_sunrise_sunset -d '{"address": "london"}'`
+
+`-f` is also shorthand for `--function`
+
+In your terminal window you should see the response from Apache OpenWhisk
+
+```bash
+{
+    "results": {
+        "astronomical_twilight_end": "8:26:54 PM",
+        "day_length": "12:48:55",
+        "civil_twilight_begin": "5:06:55 AM",
+        "solar_noon": "12:05:03 PM",
+        "sunrise": "5:40:36 AM",
+        "civil_twilight_end": "7:03:11 PM",
+        "sunset": "6:29:31 PM",
+        "nautical_twilight_end": "7:43:44 PM",
+        "astronomical_twilight_begin": "3:43:12 AM",
+        "nautical_twilight_begin": "4:26:22 AM"
+    },
+    "status": "OK"
+}
+```
+
+**For more information on the Serverless OpenWhisk plugin, please see the project repository: [https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).**

--- a/openwhisk-node-and-docker-chaining-functions/handler.js
+++ b/openwhisk-node-and-docker-chaining-functions/handler.js
@@ -1,40 +1,42 @@
 'use strict';
 
-const request = require('request')
+/* eslint-disable import/no-extraneous-dependencies */
 
-function http (url, qs) {
+const request = require('request');
+
+function http(url, qs) {
   const options = {
-    url, qs, json: true
-  }
+    url, qs, json: true,
+  };
 
-  return new Promise(function (resolve, reject) {
-    request(options, function (err, resp) {
+  return new Promise((resolve, reject) => {
+    request(options, (err, resp) => {
       if (err) {
-        console.log(err)
-        return reject({err: err})
+        console.log(err);
+        return reject({ err });
       }
       if (resp.body.status !== 'OK') {
-        console.log(resp.body.status)
-        return reject({err: resp.body.status})
+        console.log(resp.body.status);
+        return reject({ err: resp.body.status });
       }
 
-      resolve(resp.body)
-    })
-  })
+      return resolve(resp.body);
+    });
+  });
 }
 
-function location_from_address (params) {
-  if (!params.address) return Promise.reject('Missing mandatory property: address')
+function locationFromAddress(params) {
+  if (!params.address) return Promise.reject('Missing mandatory property: address');
 
-  return http('https://maps.googleapis.com/maps/api/geocode/json', {address: params.address})
+  return http('https://maps.googleapis.com/maps/api/geocode/json', { address: params.address });
 }
 
-function sunrise_sunset (params) {
-  if (!params.lat) return Promise.reject('Missing mandatory property: lat')
-  if (!params.lng) return Promise.reject('Missing mandatory property: lng')
+function sunriseSunset(params) {
+  if (!params.lat) return Promise.reject('Missing mandatory property: lat');
+  if (!params.lng) return Promise.reject('Missing mandatory property: lng');
 
-  return http('http://api.sunrise-sunset.org/json', {lat: params.lat, lng: params.lng})
+  return http('http://api.sunrise-sunset.org/json', { lat: params.lat, lng: params.lng });
 }
 
-module.exports.location_from_address = location_from_address
-module.exports.sunrise_sunset = sunrise_sunset
+module.exports.locationFromAddress = locationFromAddress;
+module.exports.sunriseSunset = sunriseSunset;

--- a/openwhisk-node-and-docker-chaining-functions/handler.js
+++ b/openwhisk-node-and-docker-chaining-functions/handler.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const request = require('request')
+
+function http (url, qs) {
+  const options = {
+    url, qs, json: true
+  }
+
+  return new Promise(function (resolve, reject) {
+    request(options, function (err, resp) {
+      if (err) {
+        console.log(err)
+        return reject({err: err})
+      }
+      if (resp.body.status !== 'OK') {
+        console.log(resp.body.status)
+        return reject({err: resp.body.status})
+      }
+
+      resolve(resp.body)
+    })
+  })
+}
+
+function location_from_address (params) {
+  if (!params.address) return Promise.reject('Missing mandatory property: address')
+
+  return http('https://maps.googleapis.com/maps/api/geocode/json', {address: params.address})
+}
+
+function sunrise_sunset (params) {
+  if (!params.lat) return Promise.reject('Missing mandatory property: lat')
+  if (!params.lng) return Promise.reject('Missing mandatory property: lng')
+
+  return http('http://api.sunrise-sunset.org/json', {lat: params.lat, lng: params.lng})
+}
+
+module.exports.location_from_address = location_from_address
+module.exports.sunrise_sunset = sunrise_sunset

--- a/openwhisk-node-and-docker-chaining-functions/package.json
+++ b/openwhisk-node-and-docker-chaining-functions/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openwhisk-node-and-docker-chaining-functions",
+  "version": "0.1.0",
+  "description": "Example of chaining function calls using sequences and docker images.",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/openwhisk-node-and-docker-chaining-functions/serverless.yml
+++ b/openwhisk-node-and-docker-chaining-functions/serverless.yml
@@ -18,9 +18,9 @@ provider:
 
 functions:
   location_from_address:
-    handler: handler.location_from_address
+    handler: handler.locationFromAddress
   sunrise_sunset:
-    handler: handler.sunrise_sunset
+    handler: handler.sunriseSunset
   jq:
     handler: jamesthomas/openwhisk-jq
     runtime: docker

--- a/openwhisk-node-and-docker-chaining-functions/serverless.yml
+++ b/openwhisk-node-and-docker-chaining-functions/serverless.yml
@@ -1,0 +1,37 @@
+# Welcome to Serverless!
+#
+# This file is the main config file for your service.
+# It's very minimal at this point and uses default values.
+# You can always add more config options for more control.
+# We've included some commented out config examples here.
+# Just uncomment any of them to get that config option.
+#
+# For full config options, check the docs:
+#    docs.serverless.com
+#
+# Happy Coding!
+
+service: testing
+
+provider:
+  name: openwhisk
+
+functions:
+  location_from_address:
+    handler: handler.location_from_address
+  sunrise_sunset:
+    handler: handler.sunrise_sunset
+  jq:
+    handler: jamesthomas/openwhisk-jq
+    runtime: docker
+    parameters: 
+      jq: '.results[0].geometry.location'
+  location_sunrise_sunset:
+    sequence: 
+      - location_from_address
+      - jq
+      - sunrise_sunset
+
+# remember to run npm install to download the provider plugin.        
+plugins:
+    - serverless-openwhisk

--- a/openwhisk-python-scheduled-cron/.gitignore
+++ b/openwhisk-python-scheduled-cron/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.serverless

--- a/openwhisk-python-scheduled-cron/README.md
+++ b/openwhisk-python-scheduled-cron/README.md
@@ -1,0 +1,56 @@
+# Serverless Boilerplate - OpenWhisk - Python
+
+Make sure `serverless` is installed. [See installation guide](https://serverless.com/framework/docs/providers/openwhisk/guide/installation/).
+
+You will also need to set up your OpenWhisk account credentials using environment variables or a configuration file. Please see the [this guide for more information](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).
+
+## 1. Install Provider Plugin
+`npm install -g serverless-openwhisk` 
+
+## 2. Install Service Dependencies
+`npm install` in this directory to download the modules from `package.json`.
+
+## 3. Deploy
+`serverless deploy` or `sls deploy`. `sls` is shorthand for the Serverless CLI command
+
+```
+$ serverless deploy
+Serverless: Packaging service...
+Serverless: Compiling Functions...
+Serverless: Compiling API Gateway definitions...
+Serverless: Compiling Rules...
+Serverless: Compiling Triggers & Feeds...
+Serverless: Deploying Functions...
+Serverless: Deploying Triggers...
+Serverless: Binding Feeds To Triggers...
+Serverless: Deploying Rules...
+Serverless: Deployment successful!
+
+Service Information
+platform:	openwhisk.ng.bluemix.net
+namespace:	_
+service:	python_service
+
+actions:
+python_service-dev-cron
+
+triggers:
+python_service_cron_schedule_trigger
+
+rules:
+python_service_cron_schedule_rule
+```
+
+## 4. Monitor function logs
+
+After sixty seconds the function should be executed and you can review the
+logging output using `serverless logs --function cron` or `serverless logs -f cron`
+
+```bash
+
+$ serverless logs -f cron
+activation (78ebd109b3bd4da5bb20c13bd2982319):
+2017-03-28 16:51:01.539 Your cron function /james.thomas@uk.ibm.com_dev/python_service-dev-cron ran at 15:51:01.538616
+```
+
+**For more information on the Serverless OpenWhisk plugin, please see the project repository: [https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).**

--- a/openwhisk-python-scheduled-cron/handler.py
+++ b/openwhisk-python-scheduled-cron/handler.py
@@ -1,0 +1,8 @@
+import datetime
+import os
+
+def run(params):
+    current_time = datetime.datetime.now().time()
+    name = os.environ['__OW_ACTION_NAME']
+    print("Your cron function " + name + " ran at " + str(current_time))
+    return {}

--- a/openwhisk-python-scheduled-cron/package.json
+++ b/openwhisk-python-scheduled-cron/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openwhisk-python-scheduled-cron",
+  "version": "0.1.0",
+  "description": "Example of creating a Python function that runs as a cron job using the serverless schedule event.",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/openwhisk-python-scheduled-cron/serverless.yml
+++ b/openwhisk-python-scheduled-cron/serverless.yml
@@ -1,0 +1,15 @@
+service: python_service
+
+provider:
+  name: openwhisk
+  runtime: python
+
+functions:
+  cron:
+    handler: handler.run
+    events:
+      - schedule: cron(* * * * *)
+
+# remember to run npm install to download the provider plugin.        
+plugins:
+    - serverless-openwhisk

--- a/openwhisk-python-simple-http-endpoint/.gitignore
+++ b/openwhisk-python-simple-http-endpoint/.gitignore
@@ -1,0 +1,3 @@
+.serverless
+*.pyc
+*.pyo

--- a/openwhisk-python-simple-http-endpoint/README.md
+++ b/openwhisk-python-simple-http-endpoint/README.md
@@ -1,0 +1,58 @@
+# Serverless Boilerplate - OpenWhisk - Python
+
+Make sure `serverless` is installed. [See installation guide](https://serverless.com/framework/docs/providers/openwhisk/guide/installation/).
+
+You will also need to set up your OpenWhisk account credentials using environment variables or a configuration file. Please see the [this guide for more information](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).
+
+## 1. Install Provider Plugin
+`npm install -g serverless-openwhisk` 
+
+## 2. Install Service Dependencies
+`npm install` in this directory to download the modules from `package.json`.
+
+## 3. Deploy
+`serverless deploy` or `sls deploy`. `sls` is shorthand for the Serverless CLI command
+
+Make a note of the API endpoint that is logged to the console during deployment.
+
+```
+endpoints:
+GET https://xxx.api-gw.mybluemix.net/python-service/ping --> python-service-dev-currentTime
+```
+
+## 4. Invoke deployed function
+`serverless invoke --function currentTime` or `serverless invoke -f currentTime`
+
+`-f` is shorthand for `--function`
+
+In your terminal window you should see the response from Apache OpenWhisk
+
+```bash
+{
+    "message": "Hello stranger, the current time is 15:59:30.983379"
+}
+```
+
+## 5. Test HTTP endpoint
+
+Use a HTTP client to access the endpoint for your function. The endpoint will
+be the API gateway root path, logged during deployment, and your configured
+function path.
+
+```
+$ http get https://xxx.api-gw.mybluemix.net/python-service/ping
+HTTP/1.1 200 OK
+...
+{
+    "message": "Hello stranger, the current time is 16:00:11.837331"
+}
+
+$ http get https://xxx.api-gw.mybluemix.net/python-service/ping?name=James
+HTTP/1.1 200 OK
+...
+{
+    "message": "Hello James, the current time is 16:00:15.749699"
+}
+```
+
+**For more information on the Serverless OpenWhisk plugin, please see the project repository: [https://serverless.com/framework/docs/providers/aws/guide/credentials/](https://serverless.com/framework/docs/providers/aws/guide/credentials/).**

--- a/openwhisk-python-simple-http-endpoint/handler.py
+++ b/openwhisk-python-simple-http-endpoint/handler.py
@@ -1,0 +1,10 @@
+import json
+import datetime
+
+def endpoint(params):
+    current_time = datetime.datetime.now().time()
+    name = params.get("name", "stranger")
+    body = {
+        "message": "Hello " + name + ", the current time is " + str(current_time)
+    }
+    return body

--- a/openwhisk-python-simple-http-endpoint/package.json
+++ b/openwhisk-python-simple-http-endpoint/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openwhisk-python-simple-http-endpoint",
+  "version": "0.1.0",
+  "description": "Example demonstrates how to setup a simple HTTP GET endpoint with OpenWhisk.",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/openwhisk-python-simple-http-endpoint/serverless.yml
+++ b/openwhisk-python-simple-http-endpoint/serverless.yml
@@ -1,0 +1,16 @@
+service: python-service
+
+provider:
+  name: openwhisk
+  runtime: python
+
+functions:
+  currentTime:
+    handler: handler.endpoint
+    events:
+      - http:
+          path: ping
+          method: get
+
+plugins:
+  - serverless-openwhisk

--- a/openwhisk-python-simple/.gitignore
+++ b/openwhisk-python-simple/.gitignore
@@ -1,0 +1,3 @@
+.serverless
+*.pyc
+*.pyo

--- a/openwhisk-python-simple/README.md
+++ b/openwhisk-python-simple/README.md
@@ -1,0 +1,52 @@
+# Serverless Boilerplate - OpenWhisk - Python
+
+Make sure `serverless` is installed. [See installation guide](https://serverless.com/framework/docs/providers/openwhisk/guide/installation/).
+
+You will also need to set up your OpenWhisk account credentials using environment variables or a configuration file. Please see the [this guide for more information](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).
+
+## 1. Install Provider Plugin
+`npm install -g serverless-openwhisk` 
+
+## 2. Install Service Dependencies
+`npm install` in this directory to download the modules from `package.json`.
+
+## 3. Deploy
+`serverless deploy` or `sls deploy`. `sls` is shorthand for the Serverless CLI command
+
+```
+Serverless: Packaging service...
+Serverless: Compiling Functions...
+Serverless: Compiling API Gateway definitions...
+Serverless: Compiling Rules...
+Serverless: Compiling Triggers & Feeds...
+Serverless: Deploying Functions...
+Serverless: Deployment successful!
+
+Service Information
+platform:	openwhisk.ng.bluemix.net
+namespace:	_
+service:	python-service
+
+actions:
+python-service-dev-greeting
+```
+
+## 4. Invoke deployed function
+`serverless invoke --function greeting` or `serverless invoke -f greeting`
+
+`-f` is shorthand for `--function`
+
+In your terminal window you should see the response from Apache OpenWhisk
+
+```bash
+$ serverless invoke -f greeting
+{
+    "greeting": "Hello stranger!"
+}
+$ serverless invoke -f greeting -d '{"name": "James"}'
+{
+    "greeting": "Hello James!"
+}
+```
+
+**For more information on the Serverless OpenWhisk plugin, please see the project repository: [https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).**

--- a/openwhisk-python-simple/handler.py
+++ b/openwhisk-python-simple/handler.py
@@ -1,0 +1,5 @@
+def endpoint(params):
+    name = params.get("name", "stranger")
+    greeting = "Hello " + name + "!"
+    print(greeting)
+    return {"greeting": greeting}

--- a/openwhisk-python-simple/package.json
+++ b/openwhisk-python-simple/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openwhisk-python-simple",
+  "version": "0.1.0",
+  "description": "Example demonstrates how to setup a simple Python function with OpenWhisk.",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/openwhisk-python-simple/serverless.yml
+++ b/openwhisk-python-simple/serverless.yml
@@ -1,0 +1,12 @@
+service: python-service
+
+provider:
+  name: openwhisk
+  runtime: python
+
+functions:
+  greeting:
+    handler: handler.endpoint
+
+plugins:
+  - serverless-openwhisk

--- a/openwhisk-swift-scheduled-cron/.gitignore
+++ b/openwhisk-swift-scheduled-cron/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.serverless

--- a/openwhisk-swift-scheduled-cron/README.md
+++ b/openwhisk-swift-scheduled-cron/README.md
@@ -1,0 +1,59 @@
+# Serverless Boilerplate - OpenWhisk - Swift
+
+Make sure `serverless` is installed. [See installation guide](https://serverless.com/framework/docs/providers/openwhisk/guide/installation/).
+
+You will also need to set up your OpenWhisk account credentials using environment variables or a configuration file. Please see the [this guide for more information](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).
+
+## 1. Install Provider Plugin
+`npm install -g serverless-openwhisk` 
+
+## 2. Install Service Dependencies
+`npm install` in this directory to download the modules from `package.json`.
+
+## 3. Deploy
+`serverless deploy` or `sls deploy`. `sls` is shorthand for the Serverless CLI command
+
+```
+$ serverless deploy
+Serverless: Packaging service...
+Serverless: Compiling Functions...
+Serverless: Compiling API Gateway definitions...
+Serverless: Compiling Rules...
+Serverless: Compiling Triggers & Feeds...
+Serverless: Deploying Functions...
+Serverless: Deploying Triggers...
+Serverless: Binding Feeds To Triggers...
+Serverless: Deploying Rules...
+Serverless: Deployment successful!
+
+Service Information
+platform:	openwhisk.ng.bluemix.net
+namespace:	_
+service:	swift_service
+
+actions:
+swift_service-dev-cron
+
+triggers:
+swift_service_cron_schedule_trigger
+
+rules:
+swift_service_cron_schedule_rule
+```
+
+## 4. Monitor function logs
+
+After sixty seconds the function should be executed and you can review the
+logging output using `serverless logs --function cron` or `serverless logs -f cron`
+
+```bash
+
+$ serverless logs -f cron
+activation (96d31322bab24cf1940e7b05b428ee34):
+2017-03-28 17:47:05.084 Compiling
+2017-03-28 17:47:06.943 swiftc status is 0
+2017-03-28 17:47:06.943 Linking
+2017-03-28 17:47:07.073 Swift function (/james.thomas@uk.ibm.com_dev/swift_service-dev-cron) was called @ 2017-03-28 16:47:07
+```
+
+**For more information on the Serverless OpenWhisk plugin, please see the project repository: [https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).**

--- a/openwhisk-swift-scheduled-cron/handler.swift
+++ b/openwhisk-swift-scheduled-cron/handler.swift
@@ -1,0 +1,14 @@
+func main(args: [String:Any]) -> [String:Any] {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    let now = formatter.string(from: Date())
+ 
+    if let value = ProcessInfo.processInfo.environment["__OW_ACTION_NAME"] {
+      print("Swift function (\(value)) was called @ \(now)")
+      return [ "cron": "Swift function (\(value)) was called @ \(now)" ]
+    }
+
+    print("Swift function was called @ \(now)")
+    return [ "cron": "Swift function was called @ \(now)" ]
+}
+

--- a/openwhisk-swift-scheduled-cron/package.json
+++ b/openwhisk-swift-scheduled-cron/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openwhisk-swift-scheduled-cron",
+  "version": "0.1.0",
+  "description": "Example of creating a Swift function that runs as a cron job using the serverless schedule event.",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/openwhisk-swift-scheduled-cron/serverless.yml
+++ b/openwhisk-swift-scheduled-cron/serverless.yml
@@ -1,0 +1,15 @@
+service: swift_service
+
+provider:
+  name: openwhisk
+  runtime: swift
+
+functions:
+  cron:
+    handler: handler.main
+    events:
+      - schedule: cron(* * * * *)
+
+# remember to run npm install to download the provider plugin.        
+plugins:
+    - serverless-openwhisk

--- a/openwhisk-swift-simple-http-endpoint/.gitignore
+++ b/openwhisk-swift-simple-http-endpoint/.gitignore
@@ -1,0 +1,3 @@
+.serverless
+*.pyc
+*.pyo

--- a/openwhisk-swift-simple-http-endpoint/README.md
+++ b/openwhisk-swift-simple-http-endpoint/README.md
@@ -1,0 +1,58 @@
+# Serverless Boilerplate - OpenWhisk - Swift
+
+Make sure `serverless` is installed. [See installation guide](https://serverless.com/framework/docs/providers/openwhisk/guide/installation/).
+
+You will also need to set up your OpenWhisk account credentials using environment variables or a configuration file. Please see the [this guide for more information](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).
+
+## 1. Install Provider Plugin
+`npm install -g serverless-openwhisk` 
+
+## 2. Install Service Dependencies
+`npm install` in this directory to download the modules from `package.json`.
+
+## 3. Deploy
+`serverless deploy` or `sls deploy`. `sls` is shorthand for the Serverless CLI command
+
+Make a note of the API endpoint that is logged to the console during deployment.
+
+```
+endpoints:
+GET https://xxx.api-gw.mybluemix.net/swift-service/ping --> swift-service-dev-ping
+```
+
+## 4. Invoke deployed function
+`serverless invoke --function ping` or `serverless invoke -f ping`
+
+`-f` is shorthand for `--function`
+
+In your terminal window you should see the response from Apache OpenWhisk
+
+```bash
+{
+    "message": "Hello stranger, the current time is 15:59:30.983379"
+}
+```
+
+## 5. Test HTTP endpoint
+
+Use a HTTP client to access the endpoint for your function. The endpoint will
+be the API gateway root path, logged during deployment, and your configured
+function path.
+
+```
+$ http get https://xxx.api-gw.mybluemix.net/swift-service/ping
+HTTP/1.1 200 OK
+...
+{
+    "message": "Hello stranger, the current time is 16:00:11.837331"
+}
+
+$ http get https://xxx.api-gw.mybluemix.net/swift-service/ping?name=James
+HTTP/1.1 200 OK
+...
+{
+    "message": "Hello James, the current time is 16:00:15.749699"
+}
+```
+
+**For more information on the Serverless OpenWhisk plugin, please see the project repository: [https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).**

--- a/openwhisk-swift-simple-http-endpoint/package.json
+++ b/openwhisk-swift-simple-http-endpoint/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openwhisk-swift-simple-http-endpoint",
+  "version": "0.1.0",
+  "description": "Example demonstrates how to setup a simple HTTP endpoint using Swift function with OpenWhisk.",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/openwhisk-swift-simple-http-endpoint/ping.swift
+++ b/openwhisk-swift-simple-http-endpoint/ping.swift
@@ -1,0 +1,12 @@
+func main(args: [String:Any]) -> [String:Any] {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    let now = formatter.string(from: Date())
+ 
+    if let name = args["name"] as? String {
+      return [ "greeting" : "Hello \(name)! The time is \(now)" ]
+    } else {
+      return [ "greeting" : "Hello stranger! The time is \(now)" ]
+    }
+}
+

--- a/openwhisk-swift-simple-http-endpoint/serverless.yml
+++ b/openwhisk-swift-simple-http-endpoint/serverless.yml
@@ -1,0 +1,17 @@
+service: swift-service
+
+provider:
+  name: openwhisk
+  runtime: swift
+
+functions:
+  ping:
+    handler: ping.main
+    events:
+      - http:
+          path: ping
+          method: get
+
+
+plugins:
+  - serverless-openwhisk

--- a/openwhisk-swift-simple/.gitignore
+++ b/openwhisk-swift-simple/.gitignore
@@ -1,0 +1,3 @@
+.serverless
+*.pyc
+*.pyo

--- a/openwhisk-swift-simple/README.md
+++ b/openwhisk-swift-simple/README.md
@@ -1,0 +1,51 @@
+# Serverless Boilerplate - OpenWhisk - Swift
+
+Make sure `serverless` is installed. [See installation guide](https://serverless.com/framework/docs/providers/openwhisk/guide/installation/).
+
+You will also need to set up your OpenWhisk account credentials using environment variables or a configuration file. Please see the [this guide for more information](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).
+
+## 1. Install Provider Plugin
+`npm install -g serverless-openwhisk` 
+
+## 2. Install Service Dependencies
+`npm install` in this directory to download the modules from `package.json`.
+
+## 3. Deploy
+`serverless deploy` or `sls deploy`. `sls` is shorthand for the Serverless CLI command
+
+```
+Serverless: Packaging service...
+Serverless: Compiling Functions...
+Serverless: Compiling API Gateway definitions...
+Serverless: Compiling Rules...
+Serverless: Compiling Triggers & Feeds...
+Serverless: Deploying Functions...
+Serverless: Deployment successful!
+
+Service Information
+platform:	openwhisk.ng.bluemix.net
+namespace:	_
+service:	swift-service
+
+actions:
+swift-service-dev-ping
+```
+
+## 4. Invoke deployed function
+`serverless invoke --function ping` or `serverless invoke -f ping`
+
+`-f` is shorthand for `--function`
+
+In your terminal window you should see the response from Apache OpenWhisk
+
+```bash
+$ serverless invoke -f ping
+{
+}
+$ serverless invoke -f ping -d '{"name": "James"}'
+{
+    "greeting": "Hello James! The time is 2017-03-28 16:24:23"
+}
+```
+
+**For more information on the Serverless OpenWhisk plugin, please see the project repository: [https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).**

--- a/openwhisk-swift-simple/package.json
+++ b/openwhisk-swift-simple/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openwhisk-swift-simple",
+  "version": "0.1.0",
+  "description": "Example demonstrates how to setup a simple Swift function with OpenWhisk.",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/openwhisk-swift-simple/ping.swift
+++ b/openwhisk-swift-simple/ping.swift
@@ -1,0 +1,12 @@
+func main(args: [String:Any]) -> [String:Any] {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    let now = formatter.string(from: Date())
+ 
+    if let name = args["name"] as? String {
+      return [ "greeting" : "Hello \(name)! The time is \(now)" ]
+    } else {
+      return [ "greeting" : "Hello stranger! The time is \(now)" ]
+    }
+}
+

--- a/openwhisk-swift-simple/serverless.yml
+++ b/openwhisk-swift-simple/serverless.yml
@@ -1,0 +1,12 @@
+service: swift-service
+
+provider:
+  name: openwhisk
+  runtime: swift
+
+functions:
+  ping:
+    handler: ping.main
+
+plugins:
+  - serverless-openwhisk


### PR DESCRIPTION
Updated OpenWhisk provider plugin supports non-Node.js runtimes 🎇🎇🎇!

I've added examples for Python, Swift, Go and Docker. 