### PR TITLE
Remove package.json from excludes in Google example

### DIFF
--- a/google-node-simple-http-endpoint/serverless.yml
+++ b/google-node-simple-http-endpoint/serverless.yml
@@ -13,7 +13,6 @@ package:
   exclude:
     - node_modules/**
     - .gitignore
-    - package.json
     - .git/**
 
 functions:


### PR DESCRIPTION
This is necessary since Google will use this file to download all the dependencies in the Cloud.