### PR TITLE
Fix type: migration should be migrate

### DIFF
--- a/aws-node-rest-api-with-dynamodb-and-offline/serverless.yml
+++ b/aws-node-rest-api-with-dynamodb-and-offline/serverless.yml
@@ -11,7 +11,7 @@ custom:
     start:
       port: 8000
       inMemory: true
-      migration: true
+      migrate: true
     migration:
       dir: offline/migrations
 


### PR DESCRIPTION
I was getting connection errors when running the dynamodb offline example.

It seems related to [a typo in their readme that was corrected recently](https://github.com/99xt/serverless-dynamodb-local/commit/19b6991675bf98acd426370bccd8e155c4cdd2b8).

Once I made that change, the offline example was working