### PR TITLE
Dynamodb streams to S3 (backup) example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,12 @@ A collection of ready-to-deploy [Serverless Framework](https://github.com/server
 <!-- ⛔️ AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click to expand) generated w/ `npm run docs`  -->
 <details>
 <summary>Click to expand</summary>
-
 - [Getting Started](#getting-started)
 - [Examples](#examples)
 - [Community Examples](#community-examples)
 - [Contributing](#contributing)
   * [Adding example code](#adding-example-code)
   * [Adding a community example](#adding-a-community-example)
-
 </details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 
@@ -40,6 +38,7 @@ serverless install -u https://github.com/serverless/examples/tree/master/folder-
 |:--------------------------- |:-----|
 | [Aws Alexa Skill](https://github.com/serverless/examples/tree/master/aws-node-alexa-skill) <br/> This example demonstrates how to use an AWS Lambdas for your custom Alexa skill. | nodeJS |
 | [Aws Auth0 Api Gateway](https://github.com/serverless/examples/tree/master/aws-node-auth0-custom-authorizers-api) <br/> Demonstration of protecting API gateway endpoints with auth0 | nodeJS |
+| [Aws Node Dynamodb Backup](https://github.com/serverless/examples/tree/master/aws-node-dynamodb-backup) <br/> Serverless DynamoDB changes backed up to S3 | nodeJS |
 | [Aws Env Variables Encrypted In A File](https://github.com/serverless/examples/tree/master/aws-node-env-variables-encrypted-in-a-file) <br/> Serverless example managing secrets in an encrypted file | nodeJS |
 | [Aws Env Variables](https://github.com/serverless/examples/tree/master/aws-node-env-variables) <br/> This example demonstrates how to use environment variables for AWS Lambdas. | nodeJS |
 | [Aws Fetch File And Store In S3](https://github.com/serverless/examples/tree/master/aws-node-fetch-file-and-store-in-s3) <br/> Fetch an image from remote source (URL) and then upload the image to a S3 bucket. | nodeJS |

--- a/aws-node-dynamodb-backup/README.md
+++ b/aws-node-dynamodb-backup/README.md
@@ -1,3 +1,10 @@
+# DynamoDB stream events to AWS S3
+
+Which effectively creates a **backup of your dynamoDB table** assuming an event
+was caught for every record. Hint: [Introduce a new field
+"backedup"](https://s.natalian.org/2017-06-22/rupdated.js) to effectively
+trigger a backup.
+
 NOTE: DynamoDB triggers need to be manually associated / setup with the lambda function.
 
 * https://ap-southeast-1.console.aws.amazon.com/dynamodb/home?region=ap-southeast-1#tables:selected=staging_EXAMPLE

--- a/aws-node-dynamodb-backup/README.md
+++ b/aws-node-dynamodb-backup/README.md
@@ -1,0 +1,6 @@
+NOTE: DynamoDB triggers need to be manually associated / setup with the lambda function.
+
+* https://ap-southeast-1.console.aws.amazon.com/dynamodb/home?region=ap-southeast-1#tables:selected=staging_EXAMPLE
+* https://ap-southeast-1.console.aws.amazon.com/dynamodb/home?region=ap-southeast-1#tables:selected=production_EXAMPLE
+
+Upon deletion the image.json becomes an empty file.

--- a/aws-node-dynamodb-backup/handler.js
+++ b/aws-node-dynamodb-backup/handler.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const aws = require('aws-sdk');
+
+const s3 = new aws.S3({ region: 'ap-southeast-1' });
+
+module.exports.backup = (event, context, callback) => {
+  const records = event.Records;
+
+  Promise.all(records.map((record) => {
+    const keysList = Object.keys(record.dynamodb.Keys).map((key) => {
+      const keyDefinition = record.dynamodb.Keys[key];
+      const type = Object.keys(keyDefinition)[0];
+      const value = keyDefinition[type];
+      return value;
+    });
+
+    const keysString = keysList.join('/');
+    const image = aws.DynamoDB.Converter.output({ M: record.dynamodb.NewImage });
+
+    return s3.putObject({
+      Bucket: process.env.BUCKET,
+      Key: `${process.env.PREFIX}/${process.env.TABLE}/${keysString}/image.json`,
+      Body: JSON.stringify(image),
+    }).promise()
+      .then((response) => {
+        console.log(`${keysString} snapshot done`, response);
+      })
+      .catch((err) => {
+        console.error('Error', err);
+      });
+  }))
+    .then(v => callback(null, v), callback);
+};

--- a/aws-node-dynamodb-backup/package.json
+++ b/aws-node-dynamodb-backup/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "aws-node-dynamodb-backup",
+  "version": "1.0.0",
+  "description": "Serverless DynamoDB changes backed up to S3",
+  "repository": "",
+  "author": "Kai Hendry <hendry@spuul.com>",
+  "license": "MIT",
+  "dependencies": {
+    "aws-sdk": "^2.73.0"
+  }
+}

--- a/aws-node-dynamodb-backup/serverless.yml
+++ b/aws-node-dynamodb-backup/serverless.yml
@@ -1,0 +1,33 @@
+service: serverless-dynamodb-backup
+
+custom:
+  bucket: EXAMPLE
+  dynamoDBTableName: "${opt:stage, self:provider.stage}_EXAMPLE"
+  prefix: FOO
+
+provider:
+  name: aws
+  runtime: nodejs6.10
+  stage: staging
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - s3:PutObject
+      Resource: "arn:aws:s3:::${self:custom.bucket}/${self:custom.prefix}/${self:custom.dynamoDBTableName}/*"
+    - Effect: Allow
+      Action:
+        - "dynamodb:GetRecords"
+        - "dynamodb:GetShardIterator"
+        - "dynamodb:DescribeStream"
+        - "dynamodb:ListStreams"
+      Resource: "arn:aws:dynamodb:ap-southeast-1:*:table/${self:custom.dynamoDBTableName}/stream/*"
+
+functions:
+  backup:
+    handler: handler.backup
+    environment:
+      STAGE: "${opt:stage, self:provider.stage}"
+      BUCKET: "${self:custom.bucket}"
+      TABLE: "${self:custom.dynamoDBTableName}"
+      PREFIX: "${self:custom.prefix}"
+    timeout: 300


### PR DESCRIPTION
I use this at work to have a backup of our DynamoDB tables. It also serves as a handy fallback when the inevitable "dynamodb throughput exceeded" occurs.