### PR TITLE
Adding PHP example for OpenWhisk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ serverless install -u https://github.com/serverless/examples/tree/master/folder-
 | [Openwhisk Node Scheduled Cron](https://github.com/serverless/examples/tree/master/openwhisk-node-scheduled-cron) <br/> Example of creating a function that runs as a cron job using the serverless schedule event. | nodeJS |
 | [Openwhisk Node Simple Http](https://github.com/serverless/examples/tree/master/openwhisk-node-simple-http-endpoint) <br/> Example demonstrates how to setup a simple HTTP GET endpoint with OpenWhisk. | nodeJS |
 | [Openwhisk Node Simple](https://github.com/serverless/examples/tree/master/openwhisk-node-simple) <br/> Simple example demonstrating OpenWhisk provider support. | nodeJS |
+| [Openwhisk Php Simple](https://github.com/serverless/examples/tree/master/openwhisk-php-simple) <br/> Example demonstrates how to setup a simple PHP function with OpenWhisk. | php |
 | [Openwhisk Python Scheduled Cron](https://github.com/serverless/examples/tree/master/openwhisk-python-scheduled-cron) <br/> Example of creating a Python function that runs as a cron job using the serverless schedule event. | python |
 | [Openwhisk Python Simple Http Endpoint](https://github.com/serverless/examples/tree/master/openwhisk-python-simple-http-endpoint) <br/> Example demonstrates how to setup a simple HTTP GET endpoint with OpenWhisk. | python |
 | [Openwhisk Python Simple](https://github.com/serverless/examples/tree/master/openwhisk-python-simple) <br/> Example demonstrates how to setup a simple Python function with OpenWhisk. | python |

--- a/generate-readme.js
+++ b/generate-readme.js
@@ -35,6 +35,8 @@ const getRuntime = (dirname) => {
     return 'python';
   } else if (dirname.match(/swift/)) {
     return 'swift';
+  } else if (dirname.match(/php/)) {
+    return 'php';
   }
   return 'nodeJS';
 };

--- a/openwhisk-php-simple/.gitignore
+++ b/openwhisk-php-simple/.gitignore
@@ -1,0 +1,3 @@
+.serverless
+*.pyc
+*.pyo

--- a/openwhisk-php-simple/README.md
+++ b/openwhisk-php-simple/README.md
@@ -1,0 +1,57 @@
+<!--
+title: OpenWhisk Serverless Simple example in PHP
+description: This example demonstrates a simple example in PHP.
+layout: Doc
+-->
+# Serverless Boilerplate - OpenWhisk - PHP
+
+Make sure `serverless` is installed. [See installation guide](https://serverless.com/framework/docs/providers/openwhisk/guide/installation/).
+
+You will also need to set up your OpenWhisk account credentials using environment variables or a configuration file. Please see the [this guide for more information](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).
+
+## 1. Install Provider Plugin
+`npm install -g serverless-openwhisk` 
+
+## 2. Install Service Dependencies
+`npm install` in this directory to download the modules from `package.json`.
+
+## 3. Deploy
+`serverless deploy` or `sls deploy`. `sls` is shorthand for the Serverless CLI command
+
+```
+Serverless: Packaging service...
+Serverless: Compiling Functions...
+Serverless: Compiling API Gateway definitions...
+Serverless: Compiling Rules...
+Serverless: Compiling Triggers & Feeds...
+Serverless: Deploying Functions...
+Serverless: Deployment successful!
+
+Service Information
+platform:	openwhisk.ng.bluemix.net
+namespace:	_
+service:	php-service
+
+actions:
+php-service-dev-greeting
+```
+
+## 4. Invoke deployed function
+`serverless invoke --function greeting` or `serverless invoke -f greeting`
+
+`-f` is shorthand for `--function`
+
+In your terminal window you should see the response from Apache OpenWhisk
+
+```bash
+$ serverless invoke -f greeting
+{
+    "greeting": "Hello stranger!"
+}
+$ serverless invoke -f greeting -d '{"name": "James"}'
+{
+    "greeting": "Hello James!"
+}
+```
+
+**For more information on the Serverless OpenWhisk plugin, please see the project repository: [https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/](https://serverless.com/framework/docs/providers/openwhisk/guide/credentials/).**

--- a/openwhisk-php-simple/handler.php
+++ b/openwhisk-php-simple/handler.php
@@ -1,0 +1,8 @@
+<?php
+function greeting(array $args) : array
+{
+    $name = $args["name"] ?? "stranger";
+    $greeting = "Hello $name!";
+    echo $greeting;
+    return ["greeting" => $greeting];
+}

--- a/openwhisk-php-simple/package.json
+++ b/openwhisk-php-simple/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openwhisk-php-simple",
+  "version": "0.1.0",
+  "description": "Example demonstrates how to setup a simple PHP function with OpenWhisk.",
+  "scripts": {
+    "postinstall": "npm link serverless-openwhisk",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/openwhisk-php-simple/serverless.yml
+++ b/openwhisk-php-simple/serverless.yml
@@ -1,0 +1,12 @@
+service: php-service
+
+provider:
+  name: openwhisk
+  runtime: php
+
+functions:
+  greeting:
+    handler: handler.greeting
+
+plugins:
+  - serverless-openwhisk


### PR DESCRIPTION
PHP support have been added to OpenWhisk provider plugin:
https://github.com/serverless/serverless-openwhisk/releases/tag/v0.9.0

I've added an example for this and fixed `generate-readme.js` to support PHP runtime.

@pmuens can you have a quick look over this before I merge?