### PR TITLE
Add JWKS token authentication (for Auth0 and AWS Cognito)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ serverless install -u https://github.com/serverless/examples/tree/master/folder-
 | Example | Runtime  |
 |:--------------------------- |:-----|
 | [Aws Alexa Skill](https://github.com/serverless/examples/tree/master/aws-node-alexa-skill) <br/> This example demonstrates how to use an AWS Lambdas for your custom Alexa skill. | nodeJS |
+| [Aws Node Auth0 Cognito Custom Authorizers Api](https://github.com/serverless/examples/tree/master/aws-node-auth0-cognito-custom-authorizers-api) <br/> Authorize your API Gateway with either Auth0 or Cognito RS256 tokens. | nodeJS |
 | [Aws Auth0 Api Gateway](https://github.com/serverless/examples/tree/master/aws-node-auth0-custom-authorizers-api) <br/> Demonstration of protecting API gateway endpoints with auth0 | nodeJS |
 | [Aws Env Variables Encrypted In A File](https://github.com/serverless/examples/tree/master/aws-node-env-variables-encrypted-in-a-file) <br/> Serverless example managing secrets in an encrypted file | nodeJS |
 | [Aws Env Variables](https://github.com/serverless/examples/tree/master/aws-node-env-variables) <br/> This example demonstrates how to use environment variables for AWS Lambdas. | nodeJS |

--- a/aws-node-auth0-cognito-custom-authorizers-api/.gitignore
+++ b/aws-node-auth0-cognito-custom-authorizers-api/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.serverless

--- a/aws-node-auth0-cognito-custom-authorizers-api/README.md
+++ b/aws-node-auth0-cognito-custom-authorizers-api/README.md
@@ -1,9 +1,9 @@
 <!--
-title: API Gateway Authorizer Function for Auth0 or AWS Cognito using RS256 tokens.
+title: API Gateway Authorizer Function for Auth0 or AWS Cognito using RS256 JSON Web Key Sets tokens.
 description: Authorize your API Gateway with either Auth0 or Cognito JWKS RS256 tokens.
 layout: Doc
 -->
-# API Gateway Authorizer Function for Auth0 or AWS Cognito using RS256 tokens.
+# API Gateway Authorizer Function for Auth0 or AWS Cognito using the [JWKS](https://auth0.com/docs/jwks) method.
 
 This is an example of how to protect API endpoints with [Auth0](https://auth0.com/) or [AWS Cognito](https://aws.amazon.com/cognito/) using JSON Web Key Sets ([JWKS](https://auth0.com/docs/jwks)) and a [custom authorizer lambda function](https://serverless.com/framework/docs/providers/aws/events/apigateway#http-endpoints-with-custom-authorizers).
 
@@ -14,28 +14,25 @@ Custom Authorizers allow you to run an AWS Lambda Function via API Gateway befor
 
 - Protect API routes for authorized users
 - Rate limiting APIs
+- Remotely revoke tokens
 
 ## Setup
 
 1. `npm install` json web token dependencies
 
-2. In [auth.js](auth.js#L10) replace the value of `iss` with either your [Auth0 iss](http://bit.ly/2hoeRXk) or [AWS Cognito ISS](http://amzn.to/2fo77UI).
-
-3. In [auth.js](auth.js#L17) replace the value of the `jwks` variable with the value of the entire JSON file which can be found either on [Auth0](http://bit.ly/2wedaP0) or [AWS Cognito](http://amzn.to/2fiE55n).
-
+2. In [auth.js](auth.js#L10) replace the value of `iss` with either your [Auth0 iss](http://bit.ly/2hoeRXk) or [AWS Cognito ISS](http://amzn.to/2fo77UI). Make sure the `iss` url ends in a trailing `/`.
 
   ```js
   /* auth.js */
   // Replace with your auth0 or Cognito values
   const iss = "https://<url>.com/";
-  const jwks = "<Paste JSON from jwks.json here>";
   ```
 
-Deploy the service with `sls deploy` and grab the public and private endpoints.
+3. Deploy the service with `sls deploy` and grab the public and private endpoints.
 
 ## Test Authentication:  
--  Use [Postman](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop?hl=en) and make a new GET request with the Header containing "Authorization" with the value being "bearer `<id_token>`" for your `api/private` url.
-- Run the following curl command:
+-  Test with [Postman](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop?hl=en): Make a new GET request with the Header containing "Authorization" with the value being "bearer `<id_token>`" for your `api/private` url.
+- Test using curl:
   ```sh
   curl --header "Authorization: bearer <id_token>" https://{api}.execute-api.{region}.amazonaws.com/api/private
   ```

--- a/aws-node-auth0-cognito-custom-authorizers-api/README.md
+++ b/aws-node-auth0-cognito-custom-authorizers-api/README.md
@@ -1,0 +1,41 @@
+<!--
+title: API Gateway Authorizer Function for Auth0 or AWS Cognito using RS256 tokens.
+description: Authorize your API Gateway with either Auth0 or Cognito JWKS RS256 tokens.
+layout: Doc
+-->
+# API Gateway Authorizer Function for Auth0 or AWS Cognito using RS256 tokens.
+
+This is an example of how to protect API endpoints with [Auth0](https://auth0.com/) or [AWS Cognito](https://aws.amazon.com/cognito/) using JSON Web Key Sets ([JWKS](https://auth0.com/docs/jwks)) and a [custom authorizer lambda function](https://serverless.com/framework/docs/providers/aws/events/apigateway#http-endpoints-with-custom-authorizers).
+
+Custom Authorizers allow you to run an AWS Lambda Function via API Gateway before your targeted AWS Lambda Function is run. This is useful for Microservice Architectures or when you simply want to do some Authorization before running your business logic.
+
+
+## Use cases
+
+- Protect API routes for authorized users
+- Rate limiting APIs
+
+## Setup
+
+1. `npm install` json web token dependencies
+
+2. In [auth.js](auth.js#L10) replace the value of `iss` with either your [Auth0 iss](http://bit.ly/2hoeRXk) or [AWS Cognito ISS](http://amzn.to/2fo77UI).
+
+3. In [auth.js](auth.js#L17) replace the value of the `jwks` variable with the value of the entire JSON file which can be found either on [Auth0](http://bit.ly/2wedaP0) or [AWS Cognito](http://amzn.to/2fiE55n).
+
+
+  ```js
+  /* auth.js */
+  // Replace with your auth0 or Cognito values
+  const iss = "https://<url>.com/";
+  const jwks = "<Paste JSON from jwks.json here>";
+  ```
+
+Deploy the service with `sls deploy` and grab the public and private endpoints.
+
+## Test Authentication:  
+-  Use [Postman](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop?hl=en) and make a new GET request with the Header containing "Authorization" with the value being "bearer `<id_token>`" for your `api/private` url.
+- Run the following curl command:
+  ```sh
+  curl --header "Authorization: bearer <id_token>" https://{api}.execute-api.{region}.amazonaws.com/api/private
+  ```

--- a/aws-node-auth0-cognito-custom-authorizers-api/auth.js
+++ b/aws-node-auth0-cognito-custom-authorizers-api/auth.js
@@ -2,19 +2,13 @@
 
 const jwk = require('jsonwebtoken');
 const jwkToPem = require('jwk-to-pem');
+const request = require('request');
 
 // For Auth0:       https://<project>.auth0.com/
 // refer to:        http://bit.ly/2hoeRXk
 // For AWS Cognito: https://cognito-idp.<region>.amazonaws.com/<user pool id>/
 // refer to:        http://amzn.to/2fo77UI
 const iss = 'https://<url>.com/';
-
-// For Auth0:       https://<project>.auth0.com/.well-known/jwks.json
-// refer to:        http://bit.ly/2wedaP0
-// For AWS Cognito: https://<project>.<region>.amazonaws.com/<user pool id>/.well-known/jwks.json
-// refer to:        http://amzn.to/2fiE55n
-// Place the content of the JSON within the `jwks` variable:
-const jwks = '<Paste JSON from jwks.json here>';
 
 // Generate policy to allow this user on this API:
 const generatePolicy = (principalId, effect, resource) => {
@@ -40,29 +34,36 @@ module.exports.authorize = (event, context, cb) => {
   if (event.authorizationToken) {
     // Remove 'bearer ' from token:
     const token = event.authorizationToken.substring(7);
-    const keys = JSON.parse(jwks);
+    // Make a request to the iss + .well-known/jwks.json URL:
+    request(
+      { url: `${iss}.well-known/jwks.json`, json: true },
+      (error, response, body) => {
+        if (error || response.statusCode !== 200) {
+          console.log('Request error:', error);
+          cb('Unauthorized');
+        }
+        const keys = body;
+        // Based on the JSON of `jwks` create a Pem:
+        const k = keys.keys[0];
+        const jwkArray = {
+          kty: k.kty,
+          n: k.n,
+          e: k.e,
+        };
+        const pem = jwkToPem(jwkArray);
 
-    // Based on the JSON of `jwks` create a Pem:
-    const k = keys.keys[0];
-    const jwkArray = {
-      kty: k.kty,
-      n: k.n,
-      e: k.e,
-    };
-    const pem = jwkToPem(jwkArray);
-
-    // Verify the token:
-    jwk.verify(token, pem, { issuer: iss }, (err, decoded) => {
-      if (err) {
-        console.log('Unauthorized user.', err.message);
-        cb('Unauthorized');
-      } else {
-        console.log('Authorized user.');
-        cb(null, generatePolicy(decoded.sub, 'Allow', event.methodArn));
-      }
-    });
+        // Verify the token:
+        jwk.verify(token, pem, { issuer: iss }, (err, decoded) => {
+          if (err) {
+            console.log('Unauthorized user:', err.message);
+            cb('Unauthorized');
+          } else {
+            cb(null, generatePolicy(decoded.sub, 'Allow', event.methodArn));
+          }
+        });
+      });
   } else {
-    console.log('No authorizationToken was set.');
+    console.log('No authorizationToken found in the header.');
     cb('Unauthorized');
   }
 };

--- a/aws-node-auth0-cognito-custom-authorizers-api/auth.js
+++ b/aws-node-auth0-cognito-custom-authorizers-api/auth.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const jwk = require('jsonwebtoken');
+const jwkToPem = require('jwk-to-pem');
+
+// For Auth0:       https://<project>.auth0.com/
+// refer to:        http://bit.ly/2hoeRXk
+// For AWS Cognito: https://cognito-idp.<region>.amazonaws.com/<user pool id>/
+// refer to:        http://amzn.to/2fo77UI
+const iss = 'https://<url>.com/';
+
+// For Auth0:       https://<project>.auth0.com/.well-known/jwks.json
+// refer to:        http://bit.ly/2wedaP0
+// For AWS Cognito: https://<project>.<region>.amazonaws.com/<user pool id>/.well-known/jwks.json
+// refer to:        http://amzn.to/2fiE55n
+// Place the content of the JSON within the `jwks` variable:
+const jwks = '<Paste JSON from jwks.json here>';
+
+// Generate policy to allow this user on this API:
+const generatePolicy = (principalId, effect, resource) => {
+  const authResponse = {};
+  authResponse.principalId = principalId;
+  if (effect && resource) {
+    const policyDocument = {};
+    policyDocument.Version = '2012-10-17';
+    policyDocument.Statement = [];
+    const statementOne = {};
+    statementOne.Action = 'execute-api:Invoke';
+    statementOne.Effect = effect;
+    statementOne.Resource = resource;
+    policyDocument.Statement[0] = statementOne;
+    authResponse.policyDocument = policyDocument;
+  }
+  return authResponse;
+};
+
+// Reusable Authorizer function, set on `authorizer` field in serverless.yml
+module.exports.authorize = (event, context, cb) => {
+  console.log('Auth function invoked');
+  if (event.authorizationToken) {
+    // Remove 'bearer ' from token:
+    const token = event.authorizationToken.substring(7);
+    const keys = JSON.parse(jwks);
+
+    // Based on the JSON of `jwks` create a Pem:
+    const k = keys.keys[0];
+    const jwkArray = {
+      kty: k.kty,
+      n: k.n,
+      e: k.e,
+    };
+    const pem = jwkToPem(jwkArray);
+
+    // Verify the token:
+    jwk.verify(token, pem, { issuer: iss }, (err, decoded) => {
+      if (err) {
+        console.log('Unauthorized user.', err.message);
+        cb('Unauthorized');
+      } else {
+        console.log('Authorized user.');
+        cb(null, generatePolicy(decoded.sub, 'Allow', event.methodArn));
+      }
+    });
+  } else {
+    console.log('No authorizationToken was set.');
+    cb('Unauthorized');
+  }
+};

--- a/aws-node-auth0-cognito-custom-authorizers-api/handler.js
+++ b/aws-node-auth0-cognito-custom-authorizers-api/handler.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// Public API
+module.exports.publicEndpoint = (event, context, cb) => {
+  cb(null, { message: 'Welcome to our Public API!' });
+};
+
+// Private API
+module.exports.privateEndpoint = (event, context, cb) => {
+  cb(null, { message: 'Only logged in users can see this' });
+};

--- a/aws-node-auth0-cognito-custom-authorizers-api/package.json
+++ b/aws-node-auth0-cognito-custom-authorizers-api/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "aws-node-auth0-cognito-custom-authorizers-api",
+  "version": "1.0.0",
+  "description": "Authorize your API Gateway with either Auth0 or Cognito RS256 tokens.",
+  "license": "MIT",
+  "dependencies": {
+    "jsonwebtoken": "^7.1.9",
+    "jwk-to-pem": "^1.2.6"
+  },
+  "author": "Shahzeb Khan"
+}

--- a/aws-node-auth0-cognito-custom-authorizers-api/package.json
+++ b/aws-node-auth0-cognito-custom-authorizers-api/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "dependencies": {
     "jsonwebtoken": "^7.1.9",
-    "jwk-to-pem": "^1.2.6"
+    "jwk-to-pem": "^1.2.6",
+    "request": "^2.82.0"
   },
   "author": "Shahzeb Khan"
 }

--- a/aws-node-auth0-cognito-custom-authorizers-api/serverless.yml
+++ b/aws-node-auth0-cognito-custom-authorizers-api/serverless.yml
@@ -1,0 +1,34 @@
+
+service: aws-node-auth0-cognito-custom-authorizers-api
+
+provider:
+  name: aws
+  runtime: nodejs4.3
+
+functions:
+  publicEndpoint:
+    handler: handler.publicEndpoint
+    events:
+      - http:
+          path: api/public
+          method: get
+          integration: lambda
+          cors: true
+  auth:
+    handler: auth.authorize
+  privateEndpoint:
+    handler: handler.privateEndpoint
+    events:
+      - http:
+          path: api/private
+          method: get
+          authorizer: auth
+          cors:
+            origins:
+              - '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token


### PR DESCRIPTION
Fixes issue #200 by adding a new authenticator node.js example which works with [JWKS](https://auth0.com/docs/jwks) tokens.
This authenticator can be used either with Auth0 or AWS Cognito (tutorial in README.md).