### PR TITLE
bugfix - [aws-node-rest-api-with-dynamodb] - Internal server error

### DIFF
--- a/aws-node-rest-api-with-dynamodb/serverless.yml
+++ b/aws-node-rest-api-with-dynamodb/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: ">=1.1.0 <2.0.0"
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   environment:
     DYNAMODB_TABLE: ${self:service}-${opt:stage, self:provider.stage}
   iamRoleStatements:


### PR DESCRIPTION
Target example: 

    aws-node-rest-api-with-dynamodb

After `deploy`, get error messages when create a new todo list:

    $ curl -X POST ${url} --data '{ "text": "Learn Serverless" }'
    {"message": "Internal server error"}

this PR is to fix above issue.