### PR TITLE
Add atom dashboard to community-examples.json

### DIFF
--- a/community-examples.json
+++ b/community-examples.json
@@ -307,5 +307,10 @@
     "name": "serverless + lambda protobuf responses",
     "description": "Demo using API Gateway and Lambda with Protocol Buffer",
     "githubUrl": "https://github.com/theburningmonk/lambda-protobuf-demo"
+  },
+  {
+    "name": "Serverless Dashboard For Atom Editor",
+    "description": "Atom editor package which allows you to deploy and visualize your serverless services with Serverless Framework on your editor.",
+    "githubUrl": "https://github.com/horike37/serverless-dashboard-for-atom"
   }
 ]


### PR DESCRIPTION
Add [Serverless Dashboard For Atom Editor](https://github.com/horike37/serverless-dashboard-for-atom) to example projects

<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->