### PR TITLE
Add Serverless SSH Command to community-examples.json

### DIFF
--- a/community-examples.json
+++ b/community-examples.json
@@ -307,5 +307,10 @@
     "name": "serverless + lambda protobuf responses",
     "description": "Demo using API Gateway and Lambda with Protocol Buffer",
     "githubUrl": "https://github.com/theburningmonk/lambda-protobuf-demo"
+  },
+  {
+    "name": "Serverless SSH Command",
+    "description": "Example of executing ssh command with OpenWhisk",
+    "githubUrl": "https://github.com/upgle/serverless-openwhisk-ssh"
   }
 ]


### PR DESCRIPTION
This example is to execute ssh command with OpenWhisk
https://github.com/upgle/serverless-openwhisk-ssh