### PR TITLE
Fixing SETUP typo in README.md

### DIFF
--- a/aws-python-rest-api-with-dynamodb/README.md
+++ b/aws-python-rest-api-with-dynamodb/README.md
@@ -21,7 +21,7 @@ The idea behind the `todos` directory is that in case you want to create a servi
 ## Setup
 
 ```bash
-npm install
+npm install -g serverless
 ```
 
 ## Deploy


### PR DESCRIPTION
As the package.json file has no dependencies running the following will have no effect:

```npm install```

The correct command should be as follows:

```npm install -g serverless```

<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->