### PR TITLE
Add AWS CloudFront Image Proxy

### DIFF
--- a/community-examples.json
+++ b/community-examples.json
@@ -368,5 +368,10 @@
     "name": "Personal Access Tokens Cron Check",
     "description": "Audit for leaked PAT in your Contentful organization. How to use serverless as cronjobs to keep your Personal Access Tokens secure",
     "githubUrl": "https://github.com/madtrick/cfpat-audit"
+  },
+  {
+    "name": "Serverless AWS CloudFront Image Proxy",
+    "description": "Make CloudFront resize images on the fly via Lambda@Edge, cache it and persists it in S3.",
+    "githubUrl": "https://github.com/skorfmann/serverless-cloudfront-image-proxy"
   }
 ]


### PR DESCRIPTION
Adds https://github.com/skorfmann/serverless-cloudfront-image-proxy as an example.