### PR TITLE
enhancement-fix/aws-node-rest-api-mongodb

### DIFF
--- a/aws-node-rest-api-mongodb/handler.js
+++ b/aws-node-rest-api-mongodb/handler.js
@@ -1,9 +1,9 @@
 const mongoose = require('mongoose');
-const bluebird = require('bluebird');
+const Promise = require('bluebird');
 const validator = require('validator');
 const UserModel = require('./model/User.js');
 
-mongoose.Promise = bluebird;
+mongoose.Promise = Promise;
 
 const mongoString = ''; // MongoDB Url
 
@@ -13,139 +13,94 @@ const createErrorResponse = (statusCode, message) => ({
   body: message || 'Incorrect id',
 });
 
-module.exports.user = (event, context, callback) => {
-  const db = mongoose.connect(mongoString).connection;
-  const id = event.pathParameters.id;
+const dbExecute = (db, fn) => db.then(fn).finally(() => db.close());
 
-  if (!validator.isAlphanumeric(id)) {
+function dbConnectAndExecute(dbUrl, fn) {
+  return dbExecute(mongoose.connect(dbUrl, { useMongoClient: true }), fn);
+}
+
+module.exports.user = (event, context, callback) => {
+  if (!validator.isAlphanumeric(event.pathParameters.id)) {
     callback(null, createErrorResponse(400, 'Incorrect id'));
-    db.close();
     return;
   }
 
-  db.once('open', () => {
+  dbConnectAndExecute(mongoString, () => (
     UserModel
       .find({ _id: event.pathParameters.id })
-      .then((user) => {
-        callback(null, { statusCode: 200, body: JSON.stringify(user) });
-      })
-      .catch((err) => {
-        callback(null, createErrorResponse(err.statusCode, err.message));
-      })
-      .finally(() => {
-        // Close db connection or node event loop won't exit , and lambda will timeout
-        db.close();
-      });
-  });
+      .then(user => callback(null, { statusCode: 200, body: JSON.stringify(user) }))
+      .catch(err => callback(null, createErrorResponse(err.statusCode, err.message)))
+  ));
 };
 
 
 module.exports.createUser = (event, context, callback) => {
-  let db = {};
-  let data = {};
-  let errs = {};
-  let user = {};
-  const mongooseId = '_id';
-
-  db = mongoose.connect(mongoString).connection;
-
-  data = JSON.parse(event.body);
-
-  user = new UserModel({ name: data.name,
-    firstname: data.firstname,
-    birth: data.birth,
-    city: data.city,
-    ip: event.requestContext.identity.sourceIp });
-
-  errs = user.validateSync();
-
-  if (errs) {
-    console.log(errs);
-    callback(null, createErrorResponse(400, 'Incorrect user data'));
-    db.close();
-    return;
-  }
-
-
-  db.once('open', () => {
-    user
-      .save()
-      .then(() => {
-        callback(null, { statusCode: 200, body: JSON.stringify({ id: user[mongooseId] }) });
-      })
-      .catch((err) => {
-        callback(null, createErrorResponse(err.statusCode, err.message));
-      })
-      .finally(() => {
-        db.close();
-      });
-  });
-};
-
-module.exports.deleteUser = (event, context, callback) => {
-  const db = mongoose.connect(mongoString).connection;
-  const id = event.pathParameters.id;
-
-  if (!validator.isAlphanumeric(id)) {
-    callback(null, createErrorResponse(400, 'Incorrect id'));
-    db.close();
-    return;
-  }
-
-  db.once('open', () => {
-    UserModel
-      .remove({ _id: event.pathParameters.id })
-      .then(() => {
-        callback(null, { statusCode: 200, body: JSON.stringify('Ok') });
-      })
-      .catch((err) => {
-        callback(null, createErrorResponse(err.statusCode, err.message));
-      })
-      .finally(() => {
-        db.close();
-      });
-  });
-};
-
-module.exports.updateUser = (event, context, callback) => {
-  const db = mongoose.connect(mongoString).connection;
   const data = JSON.parse(event.body);
-  const id = event.pathParameters.id;
-  let errs = {};
-  let user = {};
 
-  if (!validator.isAlphanumeric(id)) {
-    callback(null, createErrorResponse(400, 'Incorrect id'));
-    db.close();
-    return;
-  }
-
-  user = new UserModel({ _id: id,
+  const user = new UserModel({
     name: data.name,
     firstname: data.firstname,
     birth: data.birth,
     city: data.city,
-    ip: event.requestContext.identity.sourceIp });
+    ip: event.requestContext.identity.sourceIp,
+  });
 
-  errs = user.validateSync();
-
-  if (errs) {
-    callback(null, createErrorResponse(400, 'Incorrect parameter'));
-    db.close();
+  if (user.validateSync()) {
+    callback(null, createErrorResponse(400, 'Incorrect user data'));
     return;
   }
 
-  db.once('open', () => {
-    // UserModel.save() could be used too
-    UserModel.findByIdAndUpdate(id, user)
-      .then(() => {
-        callback(null, { statusCode: 200, body: JSON.stringify('Ok') });
-      })
-      .catch((err) => {
-        callback(err, createErrorResponse(err.statusCode, err.message));
-      })
-      .finally(() => {
-        db.close();
-      });
+  dbConnectAndExecute(mongoString, () => (
+    user
+      .save()
+      .then(() => callback(null, {
+        statusCode: 200,
+        body: JSON.stringify({ id: user.id }),
+      }))
+      .catch(err => callback(null, createErrorResponse(err.statusCode, err.message)))
+  ));
+};
+
+module.exports.deleteUser = (event, context, callback) => {
+  if (!validator.isAlphanumeric(event.pathParameters.id)) {
+    callback(null, createErrorResponse(400, 'Incorrect id'));
+    return;
+  }
+
+  dbConnectAndExecute(mongoString, () => (
+    UserModel
+      .remove({ _id: event.pathParameters.id })
+      .then(() => callback(null, { statusCode: 200, body: JSON.stringify('Ok') }))
+      .catch(err => callback(null, createErrorResponse(err.statusCode, err.message)))
+  ));
+};
+
+module.exports.updateUser = (event, context, callback) => {
+  const data = JSON.parse(event.body);
+  const id = event.pathParameters.id;
+
+  if (!validator.isAlphanumeric(id)) {
+    callback(null, createErrorResponse(400, 'Incorrect id'));
+    return;
+  }
+
+  const user = new UserModel({
+    _id: id,
+    name: data.name,
+    firstname: data.firstname,
+    birth: data.birth,
+    city: data.city,
+    ip: event.requestContext.identity.sourceIp,
   });
+
+  if (user.validateSync()) {
+    callback(null, createErrorResponse(400, 'Incorrect parameter'));
+    return;
+  }
+
+  dbConnectAndExecute(mongoString, () => (
+    UserModel.findByIdAndUpdate(id, user)
+      .then(() => callback(null, { statusCode: 200, body: JSON.stringify('Ok') }))
+      .catch(err => callback(err, createErrorResponse(err.statusCode, err.message)))
+  ));
 };

--- a/aws-node-rest-api-mongodb/model/User.js
+++ b/aws-node-rest-api-mongodb/model/User.js
@@ -1,7 +1,6 @@
 const mongoose = require('mongoose');
 const validator = require('validator');
 
-
 const model = mongoose.model('User', {
   name: {
     type: String,


### PR DESCRIPTION
This PR aims to fix the current `aws-node-rest-api-mongodb` example by using the newest declarations from mongoose, removing unused variables and lines, moving stuff to single line when possible and creating connections wrappers functions to avoid always re-declaring the `.finally(() => db.close())`.

Main change:
```
const dbExecute = (db, fn) => db.then(fn).finally(() => db.close());

function dbConnectAndExecute(dbUrl, fn) {
  return dbExecute(mongoose.connect(dbUrl, { useMongoClient: true }), fn);
}
```