### PR TITLE
Add `--delete` argument to sync command

### DIFF
--- a/aws-node-single-page-app-via-cloudfront/serverless-single-page-app-plugin/index.js
+++ b/aws-node-single-page-app-via-cloudfront/serverless-single-page-app-plugin/index.js
@@ -35,6 +35,7 @@ class ServerlessPlugin {
       'sync',
       'app/',
       `s3://${s3Bucket}/`,
+      '--delete',
     ];
     const result = spawnSync('aws', args);
     const stdout = result.stdout.toString();


### PR DESCRIPTION
The flag deletes all the files that are in the bucket that are not in the `app` directory.
Useful to Single Page Applications that generate different files on each build (like React).