### PR TITLE
Update aws-node-auth0-custom-authorizers-api Readme to reflect code

### DIFF
--- a/aws-node-auth0-custom-authorizers-api/README.md
+++ b/aws-node-auth0-custom-authorizers-api/README.md
@@ -20,13 +20,15 @@ Custom Authorizers allow you to run an AWS Lambda Function before your targeted 
 
 1. `npm install` json web token dependencies
 
-2. Setup an [auth0 client](https://auth0.com/docs/clients) and get your `client id` and `client secrets` from auth0.
+2. Setup an [auth0 application](https://auth0.com/docs/applications).
 
-3. Plugin your `AUTH0_CLIENT_ID` and `AUTH0_CLIENT_SECRET` in a new file called `secrets.json`. These will be used by the JSON web token decoder to validate private api access.
+3. Get your `Client ID` (under `applications->${YOUR_APP_NAME}->settings`) and plugin your `AUTH0_CLIENT_ID` in a new file called `secrets.json` (based on `secrets.example.json`).
 
-4. Deploy the service with `serverless-deploy` and grab the public and private endpoints.
+4. Get your `public key` (under `applications->${YOUR_APP_NAME}->settings->Show Advanced Settings->Certificates->DOWNLOAD CERTIFICATE`). Download it as `PEM` format and save it as a new file called `public_key`
 
-5. Plugin your `AUTH0_CLIENT_ID`, `AUTH0_DOMAIN`, and the `PUBLIC_ENDPOINT` + `PRIVATE_ENDPOINT` from aws in top of the `frontend/app.js` file.
+5. Deploy the service with `serverless-deploy` and grab the public and private endpoints.
+
+6. Plugin your `AUTH0_CLIENT_ID`, `AUTH0_DOMAIN`, and the `PUBLIC_ENDPOINT` + `PRIVATE_ENDPOINT` from aws in top of the `frontend/app.js` file.
 
   ```js
   /* frontend/app.js */
@@ -37,13 +39,14 @@ Custom Authorizers allow you to run an AWS Lambda Function before your targeted 
   const PRIVATE_ENDPOINT = 'https://your-aws-endpoint-here.us-east-1.amazonaws.com/dev/api/private';
   ```
 
-6. Deploy Frontend to host of your choosing and make sure to configure the `Allowed Callback URL` and `Allowed Origins` in your auth0 client in the [auth0 dashboard](https://manage.auth0.com). We used `http://auth0-serverless-protected-routes-demo.surge.sh/` for our demo.
+7. Deploy Frontend to host of your choosing and make sure to configure the `Allowed Callback URL` and `Allowed Origins` in your auth0 client in the [auth0 dashboard](https://manage.auth0.com). We used `http://auth0-serverless-protected-routes-demo.surge.sh/` for our demo.
 
 ## Custom authorizer functions
 
 [Custom authorizers functions](https://aws.amazon.com/blogs/compute/introducing-custom-authorizers-in-amazon-api-gateway/) are executed before a Lambda function is executed and return an Error or a Policy document.
 
 The Custom authorizer function is passed an `event` object as below:
+
 ```javascript
 {
   "type": "TOKEN",

--- a/aws-node-auth0-custom-authorizers-api/handler.js
+++ b/aws-node-auth0-custom-authorizers-api/handler.js
@@ -1,6 +1,6 @@
 const jwt = require('jsonwebtoken');
 
-// Set in `enviroment` of serverless.yml
+// Set in `environment` of serverless.yml
 const AUTH0_CLIENT_ID = process.env.AUTH0_CLIENT_ID;
 const AUTH0_CLIENT_PUBLIC_KEY = process.env.AUTH0_CLIENT_PUBLIC_KEY;
 

--- a/aws-node-auth0-custom-authorizers-api/public_key-example
+++ b/aws-node-auth0-custom-authorizers-api/public_key-example
@@ -1,4 +1,4 @@
 -----BEGIN CERTIFICATE-----
-PUBLIC KEY - can be found in https://manage.auth0.com -> clients -> advanced settings ->Certivifates
-Replace this file with public_key
+PUBLIC KEY - can be found in `https://manage.auth0.com -> applications->${YOUR_APP_NAME}->settings->Show Advanced Settings->Certificates->DOWNLOAD CERTIFICATE.`
+You should download the certificate in PEM format and save it as a new file called `public_key`
 -----END CERTIFICATE-----

--- a/aws-node-auth0-custom-authorizers-api/secrets.example.json
+++ b/aws-node-auth0-custom-authorizers-api/secrets.example.json
@@ -1,4 +1,3 @@
 {
-  "AUTH0_CLIENT_ID": "your-client-id",
-  "AUTH0_CLIENT_SECRET": "your-client-secret"
+  "AUTH0_CLIENT_ID": "your-client-id"
 }


### PR DESCRIPTION
512acb105359b75e0ddc1ae59c585d76d50c08f0 fixed the handler, but didn't include the nessecary `README.md` changes.