### PR TITLE
Add invalidateCloudFrontCache command to serverless-single-page-app-plugin

### DIFF
--- a/aws-node-single-page-app-via-cloudfront/README.md
+++ b/aws-node-single-page-app-via-cloudfront/README.md
@@ -11,6 +11,8 @@ To achieve these goals we use S3 in combination with CloudFront. S3 is used to s
 
 ## Prerequisite
 
+[Nodejs](https://nodejs.org/en/) (at least version 8)
+
 The `serverless-single-page-app-plugin` in this example requires the Serverless Framework version 1.2.0 or higher and the AWS Command Line Interface. Learn more [here](http://docs.aws.amazon.com/cli/latest/userguide/installing.html) on how to install the AWS Command Line Interface.
 
 ## Setup
@@ -89,6 +91,21 @@ Serverless: Web App Domain: dyj5gf0t6nqke.cloudfront.net
 Visit the printed domain domain and navigate on the web site. It should automatically redirect you to HTTPS and visiting <yourURL>/about will not result in an error with the status code 404, but rather serves the `index.html` and renders the about page.
 
 This is how it should look like: ![Screenshot](https://cloud.githubusercontent.com/assets/223045/20391786/287cb310-acd5-11e6-9eaf-89f641ed9e14.png)
+
+# Re-deploying
+
+If you make changes to your Single Page Application you might need to invalidate CloudFront's cache to make sure new files are served.
+Meaning, run:
+
+```bash
+serverless syncToS3
+```
+
+To sync your files and then:
+
+```bash
+serverless invalidateCloudFrontCache
+```
 
 ## Further Improvements
 

--- a/aws-node-single-page-app-via-cloudfront/serverless-single-page-app-plugin/index.js
+++ b/aws-node-single-page-app-via-cloudfront/serverless-single-page-app-plugin/index.js
@@ -19,12 +19,35 @@ class ServerlessPlugin {
           'domainInfo',
         ],
       },
+      invalidateCloudFrontCache: {
+        usage: 'Invalidates CloudFront cache',
+        lifecycleEvents: [
+          'invalidateCache',
+        ],
+      },
     };
 
     this.hooks = {
       'syncToS3:sync': this.syncDirectory.bind(this),
       'domainInfo:domainInfo': this.domainInfo.bind(this),
+      'invalidateCloudFrontCache:invalidateCache': this.invalidateCache.bind(
+        this,
+      ),
     };
+  }
+
+  runAwsCommand(args) {
+    const result = spawnSync('aws', args);
+    const stdout = result.stdout.toString();
+    const sterr = result.stderr.toString();
+    if (stdout) {
+      this.serverless.cli.log(stdout);
+    }
+    if (sterr) {
+      this.serverless.cli.log(sterr);
+    }
+
+    return { stdout, sterr };
   }
 
   // syncs the `app` directory to the provided bucket
@@ -37,41 +60,83 @@ class ServerlessPlugin {
       `s3://${s3Bucket}/`,
       '--delete',
     ];
-    const result = spawnSync('aws', args);
-    const stdout = result.stdout.toString();
-    const sterr = result.stderr.toString();
-    if (stdout) {
-      this.serverless.cli.log(stdout);
-    }
-    if (sterr) {
-      this.serverless.cli.log(sterr);
-    }
+    const { sterr } = this.runAwsCommand(args);
     if (!sterr) {
       this.serverless.cli.log('Successfully synced to the S3 bucket');
+    } else {
+      throw new Error('Failed syncing to the S3 bucket');
     }
   }
 
   // fetches the domain name from the CloudFront outputs and prints it out
-  domainInfo() {
+  async domainInfo() {
     const provider = this.serverless.getProvider('aws');
     const stackName = provider.naming.getStackName(this.options.stage);
-    return provider
-      .request(
-        'CloudFormation',
-        'describeStacks',
-        { StackName: stackName },
-        this.options.stage,
-        this.options.region // eslint-disable-line comma-dangle
-      )
-      .then((result) => {
-        const outputs = result.Stacks[0].Outputs;
-        const output = outputs.find(entry => entry.OutputKey === 'WebAppCloudFrontDistributionOutput');
-        if (output.OutputValue) {
-          this.serverless.cli.log(`Web App Domain: ${output.OutputValue}`);
-        } else {
-          this.serverless.cli.log('Web App Domain: Not Found');
-        }
-      });
+    const result = await provider.request(
+      'CloudFormation',
+      'describeStacks',
+      { StackName: stackName },
+      this.options.stage,
+      this.options.region,
+    );
+
+    const outputs = result.Stacks[0].Outputs;
+    const output = outputs.find(
+      entry => entry.OutputKey === 'WebAppCloudFrontDistributionOutput',
+    );
+
+    if (output && output.OutputValue) {
+      this.serverless.cli.log(`Web App Domain: ${output.OutputValue}`);
+      return output.OutputValue;
+    }
+
+    this.serverless.cli.log('Web App Domain: Not Found');
+    const error = new Error('Could not extract Web App Domain');
+    throw error;
+  }
+
+  async invalidateCache() {
+    const provider = this.serverless.getProvider('aws');
+
+    const domain = await this.domainInfo();
+
+    const result = await provider.request(
+      'CloudFront',
+      'listDistributions',
+      {},
+      this.options.stage,
+      this.options.region,
+    );
+
+    const distributions = result.DistributionList.Items;
+    const distribution = distributions.find(
+      entry => entry.DomainName === domain,
+    );
+
+    if (distribution) {
+      this.serverless.cli.log(
+        `Invalidating CloudFront distribution with id: ${distribution.Id}`,
+      );
+      const args = [
+        'cloudfront',
+        'create-invalidation',
+        '--distribution-id',
+        distribution.Id,
+        '--paths',
+        '/*',
+      ];
+      const { sterr } = this.runAwsCommand(args);
+      if (!sterr) {
+        this.serverless.cli.log('Successfully invalidated CloudFront cache');
+      } else {
+        throw new Error('Failed invalidating CloudFront cache');
+      }
+    } else {
+      const message = `Could not find distribution with domain ${domain}`;
+      const error = new Error(message);
+      this.serverless.cli.log(message);
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
Invalidating CloudFront's cache is required for s3 bucket changes to be reflected immediately.

Changes in this pr:
1. Add prerequisite to node >= 8 in readme (since I'm using `async/await` in the plugin).
2. Update readme with information about re-deploying.
3. Added the `invalidateCloudFrontCache` to the code (uses the `aws` cli).