### PR TITLE
Fix auth0 example calling the callback twice

### DIFF
--- a/aws-node-auth0-custom-authorizers-api/handler.js
+++ b/aws-node-auth0-custom-authorizers-api/handler.js
@@ -56,9 +56,6 @@ module.exports.auth = (event, context, callback) => {
     console.log('catch error. Invalid token', err);
     return callback('Unauthorized');
   }
-
-  // if for any reason you get here...
-  return callback('Unauthorized');
 };
 
 // Public API


### PR DESCRIPTION
The line I just removed was called right after an async call, so it was always executed executing the `callback` function.
Then, when the async operation complete and its callback is called, the `callback` function was called again
```
doAsyncCall((err) => {
  doThings...
  callback();
});

callback();
```

This issue was reported in https://github.com/dherault/serverless-offline/issues/405#issuecomment-433698553