### PR TITLE
GCF simple python http endpoint example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ serverless install -u https://github.com/serverless/examples/tree/master/folder-
 | [Azure Nodejs](https://github.com/serverless/examples/tree/master/azure-node-telegram-bot) <br/> Azure Functions sample for the Serverless framework | nodeJS |
 | [Google Node Simple Http Endpoint](https://github.com/serverless/examples/tree/master/google-node-simple-http-endpoint) <br/> An example of making http endpoints with the Google Cloud Functions Serverless Framework plugin. | nodeJS |
 | [Gcp Node Typescript Simple](https://github.com/serverless/examples/tree/master/google-node-typescript-http-endpoint) <br/> Simple HTTP example for GCP functions by Serverless framework with Typescript | nodeJS |
+| [Google Python Simple Http Endpoint](https://github.com/serverless/examples/tree/master/google-python-simple-http-endpoint) <br/> Example demonstrates how to setup a simple HTTP GET endpoint with python | python |
 | [Kubeless Python Simple](https://github.com/serverless/examples/tree/master/kubeless-python-schedule) <br/> This example demonstrates how to setup a simple Python function with Kubeless | python |
 | [Kubeless Python Simple](https://github.com/serverless/examples/tree/master/kubeless-python-simple) <br/> This example demonstrates how to setup a simple Python function with Kubeless | python |
 | [Openwhisk Go Simple](https://github.com/serverless/examples/tree/master/openwhisk-go-simple) <br/> Example demonstrates how to setup a simple Go function with OpenWhisk. | nodeJS |

--- a/aws-python-simple-http-endpoint/serverless.yml
+++ b/aws-python-simple-http-endpoint/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: ">=1.2.0 <2.0.0"
 
 provider:
   name: aws
-  runtime: python2.7
+  runtime: python2.7 # or python3.6, supported as of April 2017
 
 functions:
   currentTime:

--- a/google-python-simple-http-endpoint/README.md
+++ b/google-python-simple-http-endpoint/README.md
@@ -12,42 +12,46 @@ authorAvatar: 'https://avatars0.githubusercontent.com/u/3159454?v=4&s=140'
 
 # Simple HTTP Endpoint Example
 
-This example demonstrates how to setup a simple python HTTP GET endpoint. When you ping the endpoint we've set up here you'll see
-the time returned for the given request type. While the internal function is name `currentTime` the HTTP endpoint is exposed as `ping`.
+This example demonstrates how to setup a simple python HTTP GET endpoint. When you fetch the endpoint we've set up here you'll see
+the time returned for the given request type.
 
 ## Use Cases
 
 - Wrapping an existing internal or external endpoint/service
+
+## Development
+
+The GCF python runtime has a few requirements when defining your solution, in particular both a `requirements.txt` and your initial handler
+living in `main.py`. More details are listed here:
+
+https://cloud.google.com/functions/docs/concepts/python-runtime
 
 ## Deploy
 
 In order to deploy the you endpoint simply run
 
 ```bash
-serverless deploy
+serverless deploy -v
 ```
 
 The expected result should be similar to:
 
 ```bash
-Serverless: Packaging service...
-Serverless: Uploading CloudFormation file to S3...
-Serverless: Uploading service .zip file to S3 (758 B)...
-Serverless: Updating Stack...
-Serverless: Checking Stack update progress...
-..........
-Serverless: Stack update finished...
-
+Serverless: Uploading artifacts...
+Serverless: Artifacts successfully uploaded...
+Serverless: Updating deployment...
+Serverless: Checking deployment update progress...
+..............
+Serverless: Done...
 Service Information
 service: python-simple-http-endpoint
+project: <project_name>
 stage: dev
-region: us-east-1
-api keys:
-  None
-endpoints:
-  GET - https://f7r5srabr3.execute-api.us-east-1.amazonaws.com/dev/ping
-functions:
-  aws-python-simple-http-endpoint-dev-currentTime: arn:aws:lambda:us-east-1:377024778620:function:aws-python-simple-http-endpoint-dev-currentTime
+region: <region>
+
+Deployed functions
+currentTime
+  https://<region>-<project_name>.cloudfunctions.net/endpoint
 ```
 
 ## Usage
@@ -55,30 +59,41 @@ functions:
 You can now invoke the Cloud Function directly and even see the resulting log via
 
 ```bash
-serverless invoke --function currentTime --log
+serverless invoke --function currentTime
 ```
 
 The expected result should be similar to:
 
 ```bash
-{
-    "body": "{\"message\": \"Hello, the current time is 15:40:19.009371\"}",
-    "statusCode": 200
+Serverless: tudkstajertt {
+    "statusCode": 200,
+    "body": {
+        "message": "Received a POST request at 17:44:58.448696"
+    }
 }
---------------------------------------------------------------------
-START RequestId: a26699d3-b3ee-11e6-98f33f952e8294 Version: $LATEST
-END RequestId: a26699d3-b3ee-11e6-98f33f952e8294
-REPORT RequestId: a26699d3-b3ee-11e6-98f33f952e8294	Duration: 0.23 ms	Billed Duration: 100 ms 	Memory Size: 1024 MB	Max Memory Used: 15 MB
+```
+
+And to check out the logs directly from sls, you can run the following:
+
+```bash
+serverless logs --function currentTime
+...
+Serverless: Displaying the 10 most recent log(s):
+
+2018-11-21T17:44:58.450200631Z: Function execution took 7 ms, finished with status code: 200
+2018-11-21T17:44:58.443618562Z: Function execution started
+2018-11-21T17:43:40.651063187Z: Function execution took 8 ms, finished with status code: 200
+2018-11-21T17:43:40.644123421Z: Function execution started
+2018-11-21T17:43:35.688702419Z: Function execution took 25 ms, finished with status code: 200
+2018-11-21T17:43:35.664212161Z: Function execution started
+2018-11-21T17:40:46.166468516Z: Function execution took 6 ms, finished with status code: 200
+2018-11-21T17:40:46.161422666Z: Function execution started
+2018-11-21T17:33:27.004019351Z: Function execution took 10 ms, finished with status code: 200
+2018-11-21T17:33:26.994600775Z: Function execution started
 ```
 
 Finally you can send an HTTP request directly to the endpoint using a tool like curl
 
 ```bash
-curl https://XXXXXXX.execute-api.us-east-1.amazonaws.com/dev/ping
-```
-
-The expected result should be similar to:
-
-```bash
-{"message": "Hello, the current time is 15:38:53.668501"}%
+curl https://<region>-<project_name>.cloudfunctions.net/endpoint
 ```

--- a/google-python-simple-http-endpoint/README.md
+++ b/google-python-simple-http-endpoint/README.md
@@ -1,0 +1,84 @@
+<!--
+title: 'GCF Simple HTTP Endpoint example in Python'
+description: 'This example demonstrates how to setup a simple python HTTP GET endpoint on GCP Cloud Functions. When you ping the endpoint we've set up you'll see the time returned for the given request type.'
+layout: Doc
+framework: v1
+platform: 'Google Cloud'
+language: Python
+authorLink: 'https://github.com/sebito91'
+authorName: 'Sebastian Borza
+authorAvatar: 'https://avatars0.githubusercontent.com/u/3159454?v=4&s=140'
+-->
+
+# Simple HTTP Endpoint Example
+
+This example demonstrates how to setup a simple python HTTP GET endpoint. When you ping the endpoint we've set up here you'll see
+the time returned for the given request type. While the internal function is name `currentTime` the HTTP endpoint is exposed as `ping`.
+
+## Use Cases
+
+- Wrapping an existing internal or external endpoint/service
+
+## Deploy
+
+In order to deploy the you endpoint simply run
+
+```bash
+serverless deploy
+```
+
+The expected result should be similar to:
+
+```bash
+Serverless: Packaging service...
+Serverless: Uploading CloudFormation file to S3...
+Serverless: Uploading service .zip file to S3 (758 B)...
+Serverless: Updating Stack...
+Serverless: Checking Stack update progress...
+..........
+Serverless: Stack update finished...
+
+Service Information
+service: python-simple-http-endpoint
+stage: dev
+region: us-east-1
+api keys:
+  None
+endpoints:
+  GET - https://f7r5srabr3.execute-api.us-east-1.amazonaws.com/dev/ping
+functions:
+  aws-python-simple-http-endpoint-dev-currentTime: arn:aws:lambda:us-east-1:377024778620:function:aws-python-simple-http-endpoint-dev-currentTime
+```
+
+## Usage
+
+You can now invoke the Cloud Function directly and even see the resulting log via
+
+```bash
+serverless invoke --function currentTime --log
+```
+
+The expected result should be similar to:
+
+```bash
+{
+    "body": "{\"message\": \"Hello, the current time is 15:40:19.009371\"}",
+    "statusCode": 200
+}
+--------------------------------------------------------------------
+START RequestId: a26699d3-b3ee-11e6-98f33f952e8294 Version: $LATEST
+END RequestId: a26699d3-b3ee-11e6-98f33f952e8294
+REPORT RequestId: a26699d3-b3ee-11e6-98f33f952e8294	Duration: 0.23 ms	Billed Duration: 100 ms 	Memory Size: 1024 MB	Max Memory Used: 15 MB
+```
+
+Finally you can send an HTTP request directly to the endpoint using a tool like curl
+
+```bash
+curl https://XXXXXXX.execute-api.us-east-1.amazonaws.com/dev/ping
+```
+
+The expected result should be similar to:
+
+```bash
+{"message": "Hello, the current time is 15:38:53.668501"}%
+```

--- a/google-python-simple-http-endpoint/handler.py
+++ b/google-python-simple-http-endpoint/handler.py
@@ -1,0 +1,30 @@
+"""GCP HTTP Cloud Function Example."""
+# -*- coding: utf-8 -*-
+
+import json
+import datetime
+
+
+def endpoint(request):
+    """GCP HTTP Cloud Function Example.
+
+    Args:
+        request (flask.Request)
+
+    Returns:
+        The response text, or any set of values that can be turned into a
+        Response object using `make_response`
+        <http://flask.pocoo.org/docs/0.12/api/#flask.Flask.make_response>.
+
+    """
+    current_time = datetime.datetime.now().time()
+    body = {
+        "message": "Received a {} request at {}".format(request.method, str(current_time))
+    }
+
+    response = {
+        "statusCode": 200,
+        "body": json.dumps(body)
+    }
+
+    return response

--- a/google-python-simple-http-endpoint/main.py
+++ b/google-python-simple-http-endpoint/main.py
@@ -24,7 +24,7 @@ def endpoint(request):
 
     response = {
         "statusCode": 200,
-        "body": json.dumps(body)
+        "body": body
     }
 
-    return response
+    return json.dumps(response, indent=4)

--- a/google-python-simple-http-endpoint/package.json
+++ b/google-python-simple-http-endpoint/package.json
@@ -4,11 +4,11 @@
   "description": "Example demonstrates how to setup a simple HTTP GET endpoint with python",
   "author": "Sebastian Borza <sebito91@gmail.com>",
   "license": "MIT",
-  "main": "index.js",
+  "main": "handler.py",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "serverless-google-cloudfunctions": "^1.1.0"
+    "serverless-google-cloudfunctions": "^2.1.0"
   }
 }

--- a/google-python-simple-http-endpoint/package.json
+++ b/google-python-simple-http-endpoint/package.json
@@ -3,5 +3,12 @@
   "version": "0.0.1",
   "description": "Example demonstrates how to setup a simple HTTP GET endpoint with python",
   "author": "Sebastian Borza <sebito91@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "serverless-google-cloudfunctions": "^1.1.0"
+  }
 }

--- a/google-python-simple-http-endpoint/package.json
+++ b/google-python-simple-http-endpoint/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "google-python-simple-http-endpoint",
+  "version": "0.0.1",
+  "description": "Example demonstrates how to setup a simple HTTP GET endpoint with python",
+  "author": "Sebastian Borza <sebito91@gmail.com>",
+  "license": "MIT"
+}

--- a/google-python-simple-http-endpoint/serverless.yml
+++ b/google-python-simple-http-endpoint/serverless.yml
@@ -1,0 +1,24 @@
+service: python-simple-http-endpoint
+
+frameworkVersion: ">=1.2.0 <2.0.0"
+
+package:
+  exclude:
+    - node_modules/**
+    - .gitignore
+    - .git/**
+
+provider:
+  name: google
+  runtime: python3.7
+  region: us-central1
+  project: sebito91
+  credentials: ~/.gcloud/keyfile.json # path must be absolute
+
+functions:
+  currentTime:
+    handler: handler.endpoint
+    events:
+      - http:
+          path: ping
+          method: get

--- a/google-python-simple-http-endpoint/serverless.yml
+++ b/google-python-simple-http-endpoint/serverless.yml
@@ -21,6 +21,4 @@ functions:
   currentTime:
     handler: endpoint
     events:
-      - http:
-          path: ping
-          method: get
+      - http: path

--- a/google-python-simple-http-endpoint/serverless.yml
+++ b/google-python-simple-http-endpoint/serverless.yml
@@ -8,15 +8,18 @@ package:
     - .gitignore
     - .git/**
 
+plugins:
+  - serverless-google-cloudfunctions
+
 provider:
   name: google
   runtime: python37
-  project: sebito91
-  credentials: ~/.gcloud/serverless_keyfile.json # path must be absolute
+  project: <projectnamehere-1234>
+  credentials: ~/.gcloud/keyfile.json # path must be absolute
 
 functions:
   currentTime:
-    handler: handler.endpoint
+    handler: endpoint
     events:
       - http:
           path: ping

--- a/google-python-simple-http-endpoint/serverless.yml
+++ b/google-python-simple-http-endpoint/serverless.yml
@@ -10,10 +10,9 @@ package:
 
 provider:
   name: google
-  runtime: python3.7
-  region: us-central1
+  runtime: python37
   project: sebito91
-  credentials: ~/.gcloud/keyfile.json # path must be absolute
+  credentials: ~/.gcloud/serverless_keyfile.json # path must be absolute
 
 functions:
   currentTime:


### PR DESCRIPTION
This example demonstrates how to setup a simple python HTTP GET endpoint within the GCF python3.7 runtime. When you fetch the endpoint we've set up here you'll see the time returned for the given request type.