### PR TITLE
adding GCF golang runtime example with simple http endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ serverless install -u https://github.com/serverless/examples/tree/master/folder-
 | [Azure Nodejs](https://github.com/serverless/examples/tree/master/azure-node-line-bot) <br/> Azure Functions sample for the Serverless framework | nodeJS |
 | [Azure Node Simple Http Endpoint](https://github.com/serverless/examples/tree/master/azure-node-simple-http-endpoint) <br/> An example of making http endpoints with the Azure Functions Serverless Framework plugin | nodeJS |
 | [Azure Nodejs](https://github.com/serverless/examples/tree/master/azure-node-telegram-bot) <br/> Azure Functions sample for the Serverless framework | nodeJS |
+| [Google Golang Simple Http Endpoint](https://github.com/serverless/examples/tree/master/google-golang-simple-http-endpoint) <br/> Example demonstrates how to setup a simple HTTP GET endpoint with golang | golang |
 | [Google Node Simple Http Endpoint](https://github.com/serverless/examples/tree/master/google-node-simple-http-endpoint) <br/> An example of making http endpoints with the Google Cloud Functions Serverless Framework plugin. | nodeJS |
 | [Gcp Node Typescript Simple](https://github.com/serverless/examples/tree/master/google-node-typescript-http-endpoint) <br/> Simple HTTP example for GCP functions by Serverless framework with Typescript | nodeJS |
 | [Google Python Simple Http Endpoint](https://github.com/serverless/examples/tree/master/google-python-simple-http-endpoint) <br/> Example demonstrates how to setup a simple HTTP GET endpoint with python | python |

--- a/google-golang-simple-http-endpoint/.gcloudignore
+++ b/google-golang-simple-http-endpoint/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+node_modules
+.serverless

--- a/google-golang-simple-http-endpoint/README.md
+++ b/google-golang-simple-http-endpoint/README.md
@@ -1,0 +1,101 @@
+<!--
+title: 'GCF Simple HTTP Endpoint example in golang'
+description: This example demonstrates how to setup a simple golang HTTP GET endpoint on GCP Cloud Functions. When you ping the endpoint we've set up you'll see the time returned for the given request type.
+layout: Doc
+framework: v1
+platform: 'Google Cloud'
+language: golang
+authorLink: 'https://github.com/sebito91'
+authorName: 'Sebastian Borza'
+authorAvatar: 'https://avatars0.githubusercontent.com/u/3159454?v=4&s=140'
+-->
+
+# Simple HTTP Endpoint Example
+
+This example demonstrates how to setup a simple golang HTTP GET endpoint. When you fetch the endpoint we've set up here you'll see
+the time returned for the given request type.
+
+## Use Cases
+
+- Wrapping an existing internal or external endpoint/service
+
+## Development
+
+The GCF golang runtime has a few requirements when defining your solution, namely:
+
+- Your function must be exported (e.g `Hello`)
+- You must define a non-main package, which can have an arbitrary name: `package p`
+- Your function code may not contain `package main` or a `func main()`
+
+Since this is an alpha runtime provided by GCF the docs are not yet available for consumption. We'll update this README
+once those instructions are made public.
+
+## Deploy
+
+In order to deploy the you endpoint simply run
+
+```bash
+serverless deploy -v
+```
+
+The expected result should be similar to:
+
+```bash
+Serverless: Uploading artifacts...
+Serverless: Artifacts successfully uploaded...
+Serverless: Updating deployment...
+Serverless: Checking deployment update progress...
+..............
+Serverless: Done...
+Service Information
+service: golang-simple-http-endpoint
+project: <project_name>
+stage: dev
+region: <region>
+
+Deployed functions
+currentTime
+  https://<region>-<project_name>.cloudfunctions.net/endpoint
+```
+
+## Usage
+
+You can now invoke the Cloud Function directly and even see the resulting log via
+
+```bash
+serverless invoke --function hello 
+```
+
+The expected result should be similar to:
+
+```bash
+Serverless: 6xthowrso4u2 {"message":"Go Serverless v1! Your function executed hello successfully!"}
+```
+
+And to check out the logs directly from sls, you can run the following:
+
+```bash
+serverless logs --function hello 
+...
+Serverless: Displaying the 10 most recent log(s):
+
+2018-11-21T17:44:58.450200631Z: Function execution took 7 ms, finished with status code: 200
+2018-11-21T17:44:58.443618562Z: Function execution started
+2018-11-21T17:43:40.651063187Z: Function execution took 8 ms, finished with status code: 200
+2018-11-21T17:43:40.644123421Z: Function execution started
+2018-11-21T17:43:35.688702419Z: Function execution took 25 ms, finished with status code: 200
+2018-11-21T17:43:35.664212161Z: Function execution started
+2018-11-21T17:40:46.166468516Z: Function execution took 6 ms, finished with status code: 200
+2018-11-21T17:40:46.161422666Z: Function execution started
+2018-11-21T17:33:27.004019351Z: Function execution took 10 ms, finished with status code: 200
+2018-11-21T17:33:26.994600775Z: Function execution started
+```
+
+Finally you can send an HTTP request directly to the endpoint using a tool like curl:
+
+```bash
+curl https://<region>-<project_name>.cloudfunctions.net/Hello
+```
+
+**NOTE:** notice that the request terminates with your golang exported function name, not the serverless function
+name you've defined.

--- a/google-golang-simple-http-endpoint/hello.go
+++ b/google-golang-simple-http-endpoint/hello.go
@@ -1,0 +1,27 @@
+package hello
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+// Hello is a simple HTTP handler that addresses HTTP requests to the /hello endpoint
+func Hello(w http.ResponseWriter, r *http.Request) {
+	var buf bytes.Buffer
+
+	body, err := json.Marshal(map[string]interface{}{
+		"message": "Go Serverless v1! Your function executed hello successfully!",
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(err.Error()))
+		return
+	}
+	json.HTMLEscape(&buf, body)
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("MyCompany-Func-Reply", "hello-handler")
+	w.Write(buf.Bytes())
+}

--- a/google-golang-simple-http-endpoint/package.json
+++ b/google-golang-simple-http-endpoint/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "google-golang-simple-http-endpoint",
+  "version": "0.0.1",
+  "description": "Example demonstrates how to setup a simple HTTP GET endpoint with golang",
+  "author": "Sebastian Borza <sebito91@gmail.com>",
+  "license": "MIT",
+  "main": "handler.py",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "serverless-google-cloudfunctions": "^2.1.0"
+  }
+}

--- a/google-golang-simple-http-endpoint/serverless.yml
+++ b/google-golang-simple-http-endpoint/serverless.yml
@@ -1,0 +1,28 @@
+service: golang-simple-http-endpoint
+
+frameworkVersion: ">=1.33.0 <2.0.0"
+
+package:
+  exclude:
+    - node_modules/**
+    - .gitignore
+    - .git/**
+
+plugins:
+  - serverless-google-cloudfunctions
+
+# The GCF credentials can be a little tricky to set up. Luckily we've documented this for you here:
+# https://serverless.com/framework/docs/providers/google/guide/credentials/
+#
+# NOTE: the golang runtime is currently in alpha state, you must have access from google to use the alpha toolchain
+provider:
+  name: google
+  runtime: go111                           # currently both vendored and go.mod repos are supported
+  project: sborza-91                    # replace with your project name here
+  credentials: ~/.gcloud/slsframework.json # path must be absolute, change to whichever keyfile you need
+
+functions:
+  hello:
+    handler: Hello
+    events:
+      - http: path


### PR DESCRIPTION
The golang runtime in GCF is still in `alpha` but it slated for release to `beta` shortly. In the meantime let's get a few examples working with the serverless framework!

**NOTES**
- Your function must be exported (e.g `Hello`)
- You must define a non-main package, which can have an arbitrary name: `package p`
- Your function code may not contain `package main` or a `func main()`