### PR TITLE
point newsletter example to updated fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ serverless install -u https://github.com/author/project -n my-project
 | **[Serverless Messenger Boilerplate](https://github.com/SC5/serverless-messenger-boilerplate)** <br/> Serverless messenger bot boilerplate | [SC5](http://github.com/SC5) |
 | **[Serverless Modern Koa](https://github.com/barczaG/serverless-modern-koa)** <br/> Serverless modern koa starter kit | [barczaG](http://github.com/barczaG) |
 | **[Serverless Msg Gateway](https://github.com/yonahforst/msg-gateway)** <br/> A messaging aggregator for kik, skype, twilio, telegram, & messenger. Send and receive messages in a standard format. | [yonahforst](http://github.com/yonahforst) |
-| **[Serverless Newsletter Signup](https://github.com/ivanderbu2/serverless-newsletter-signup)** <br/> Saves user details into DynamoDB table. Required values are email, first_name and last_name. | [ivanderbu2](http://github.com/ivanderbu2) |
+| **[Serverless Newsletter Signup](https://github.com/dschep/serverless-newsletter-signup)** <br/> Saves user details into DynamoDB table. Required values are email, first_name and last_name. | [dschep](http://github.com/dschep) |
 | **[Serverless Npm Registry](https://github.com/craftship/yith)** <br/> Serverless private npm registry, proxy and cache. | [craftship](http://github.com/craftship) |
 | **[Serverless Pokego](https://github.com/jch254/pokego-serverless)** <br/> Serverless-powered API to fetch nearby Pokemon Go data | [jch254](http://github.com/jch254) |
 | **[Serverless Postgraphql](https://github.com/rentrop/serverless-postgraphql)** <br/> GraphQL endpoint for PostgreSQL using postgraphql | [rentrop](http://github.com/rentrop) |

--- a/community-examples.json
+++ b/community-examples.json
@@ -114,7 +114,7 @@
   {
     "name": "serverless-newsletter-signup",
     "description": "Saves user details into DynamoDB table. Required values are email, first_name and last_name.",
-    "githubUrl": "https://github.com/ivanderbu2/serverless-newsletter-signup"
+    "githubUrl": "https://github.com/dschep/serverless-newsletter-signup"
   },
   {
     "name": "serverless-slack-cron",


### PR DESCRIPTION
initial one had a few issues, including blocking ones (eg: runtime=node4) and the maintainer has not responded to a PR: https://github.com/ivanderbu2/serverless-newsletter-signup/pull/2
