### PR TITLE
Fix/open access policy in aws-golang-dynamo-stream-to-elasticsearch

### DIFF
--- a/aws-golang-dynamo-stream-to-elasticsearch/README.md
+++ b/aws-golang-dynamo-stream-to-elasticsearch/README.md
@@ -40,3 +40,26 @@ You should be able to create a Kibana index by navigating to your Kibana endpoin
 Follow the instructions to create the index, and you should now be able to query your data like so:
 
 ![query](docs/query.png)
+
+
+## Access Policy for Kibana
+The Example itself is running without any further Policy definition, since the Lambda execution role has access to the ES endpoint.
+However, if you want to access Kibana with your Browser - there is an additonal definition needed.
+
+Possible restrictions can be done with aws cognito user auth, aws user auth, IP based or open access (not recommended):
+e.g. with ip restriction:
+```
+        AccessPolicies:
+          Version: "2012-10-17"
+          Statement:
+            -
+              Effect: "Allow"
+              Principal:
+                AWS: "*"
+              Action: "es:*"
+              Resource: "*"
+              Condition:
+                IpAddress:
+                  aws:sourceIp:
+                    - "123.123.123.123"
+```

--- a/aws-golang-dynamo-stream-to-elasticsearch/serverless.yml
+++ b/aws-golang-dynamo-stream-to-elasticsearch/serverless.yml
@@ -90,15 +90,17 @@ resources:
           Iops: 0
           VolumeSize: 10
           VolumeType: "gp2"
-        AccessPolicies:
-          Version: "2012-10-17"
-          Statement:
-            -
-              Effect: "Allow"
-              Principal:
-                AWS: "*"
-              Action: "es:*"
-              Resource: "*"
+
+        ## Attention! Before you enable this lines, check out the README to avoid an open access policy
+        # AccessPolicies:
+        #   Version: "2012-10-17"
+        #   Statement:
+        #     -
+        #       Effect: "Allow"
+        #       Principal:
+        #         AWS: "*"
+        #       Action: "es:*"
+        #       Resource: "*"
         AdvancedOptions:
           rest.action.multi.allow_explicit_index: "true"
 


### PR DESCRIPTION
disable AccessPolicies per default

Since the Lambda has access to ES anyway via lambda role, it's not necessary to have an open access set per default.