### PR TITLE
aws-node-single-page-app-via-cloudfront - Read in aws-profile option when calling AWS CLI in

### DIFF
--- a/aws-node-single-page-app-via-cloudfront/serverless-single-page-app-plugin/index.js
+++ b/aws-node-single-page-app-via-cloudfront/serverless-single-page-app-plugin/index.js
@@ -60,6 +60,11 @@ class ServerlessPlugin {
       `s3://${s3Bucket}/`,
       '--delete',
     ];
+    if (this.serverless.variables.options['aws-profile']) {
+      args.push(
+        `--profile=${this.serverless.variables.options['aws-profile']}`
+      );
+    }
     const { sterr } = this.runAwsCommand(args);
     if (!sterr) {
       this.serverless.cli.log('Successfully synced to the S3 bucket');
@@ -125,6 +130,11 @@ class ServerlessPlugin {
         '--paths',
         '/*',
       ];
+      if (this.serverless.variables.options['aws-profile']) {
+        args.push(
+          `--profile=${this.serverless.variables.options['aws-profile']}`
+        );
+      }
       const { sterr } = this.runAwsCommand(args);
       if (!sterr) {
         this.serverless.cli.log('Successfully invalidated CloudFront cache');


### PR DESCRIPTION
This ensures the [`--aws-profile`](https://serverless.com/framework/docs/providers/aws/guide/credentials#using-the-aws-profile-option) option is properly passed to the AWS CLI if provided for `aws-node-single-page-app-via-cloudfront`.

Example:

```
serverless syncToS3 --aws-profile <someProfile>
```