### PR TITLE
fix: await nuxt ready state

### DIFF
--- a/aws-node-vue-nuxt-ssr/nuxt.js
+++ b/aws-node-vue-nuxt-ssr/nuxt.js
@@ -3,9 +3,11 @@ const { Nuxt } = require('nuxt');
 const path = require('path');
 const config = require('./nuxt.config.js');
 
-const app = express();
-const nuxt = new Nuxt(config);
-app.use('/_nuxt', express.static(path.join(__dirname, '.nuxt', 'dist')));
-app.use(nuxt.render);
-
-module.exports = app;
+module.exports = async function() {
+  const app = express()
+  const nuxt = new Nuxt(config)
+  await nuxt.ready()
+  app.use('/_nuxt', express.static(path.join(__dirname, '.nuxt', 'dist')))
+  app.use(nuxt.render)
+  return app
+}


### PR DESCRIPTION
# Warning - Untested code ahead

Hey all :wave: 	

After Nuxt v2.5 (https://github.com/nuxt/nuxt.js/releases/tag/v2.5.0), awaiting the Nuxt ready state has to be done. It was already required before but had no huge downsides if missing