### PR TITLE
eslint: Mark as root config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "extends": "airbnb-base",
   "env": {
     "node": true


### PR DESCRIPTION
This marks the main directory as the top-level for the project, stopping ESLint from looking in parent directories for more .eslintrc files.