### PR TITLE
Python 3.7 support in comment

### DIFF
--- a/aws-python-simple-http-endpoint/serverless.yml
+++ b/aws-python-simple-http-endpoint/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: ">=1.2.0 <2.0.0"
 
 provider:
   name: aws
-  runtime: python2.7 # or python3.6, supported as of April 2017
+  runtime: python2.7 # or python3.7, supported as of November 2018
 
 functions:
   currentTime:


### PR DESCRIPTION
As of November 2019, [Python 3.7 is supported by AWS Lambda]. Let's update the comment from Python 3.6 to 3.7, as it is the [latest stable release](https://docs.python.org/3.7/) of the language.

If this change is approved, we might consider adding the same comment to Python `serverless.yml` files.