### PR TITLE
Return is not needed after an exception is raised

### DIFF
--- a/aws-python-rest-api-with-dynamodb/todos/create.py
+++ b/aws-python-rest-api-with-dynamodb/todos/create.py
@@ -13,7 +13,6 @@ def create(event, context):
     if 'text' not in data:
         logging.error("Validation Failed")
         raise Exception("Couldn't create the todo item.")
-        return
 
     timestamp = int(time.time() * 1000)
 


### PR DESCRIPTION
`return` statement is not needed after an exception is raised.