### PR TITLE
Fix typo + new NodeJS version

### DIFF
--- a/aws-node-auth0-custom-authorizers-api/README.md
+++ b/aws-node-auth0-custom-authorizers-api/README.md
@@ -32,7 +32,7 @@ Custom Authorizers allow you to run an AWS Lambda Function before your targeted 
 
 4. Get your `public key` (under `applications->${YOUR_APP_NAME}->settings->Show Advanced Settings->Certificates->DOWNLOAD CERTIFICATE`). Download it as `PEM` format and save it as a new file called `public_key`
 
-5. Deploy the service with `serverless-deploy` and grab the public and private endpoints.
+5. Deploy the service with `serverless deploy` and grab the public and private endpoints.
 
 6. Plugin your `AUTH0_CLIENT_ID`, `AUTH0_DOMAIN`, and the `PUBLIC_ENDPOINT` + `PRIVATE_ENDPOINT` from aws in top of the `frontend/app.js` file.
 

--- a/aws-node-auth0-custom-authorizers-api/serverless.yml
+++ b/aws-node-auth0-custom-authorizers-api/serverless.yml
@@ -6,7 +6,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
   region: us-west-2
   environment:
     AUTH0_CLIENT_ID: ${file(./secrets.json):AUTH0_CLIENT_ID}


### PR DESCRIPTION
What's new?

- fixed typo in README
- NodeJS version `6.10` in serverless.yml is deprecated. I updated the serverless.yml file accordingly.
