### PR TITLE
Update timeout to match API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ serverless install -u https://github.com/serverless/examples/tree/master/folder-
 | [Aws Auth0 Api Gateway](https://github.com/serverless/examples/tree/master/aws-node-auth0-custom-authorizers-api) <br/> Demonstration of protecting API gateway endpoints with auth0 | nodeJS |
 | [Aws Node Dynamic Image Resizer](https://github.com/serverless/examples/tree/master/aws-node-dynamic-image-resizer)  | nodeJS |
 | [Aws Node Dynamodb Backup](https://github.com/serverless/examples/tree/master/aws-node-dynamodb-backup) <br/> Serverless DynamoDB changes backed up to S3 | nodeJS |
-| [Aws Node Fullstack](https://github.com/serverless/examples/tree/master/aws-node-fullstack) <br/> Demonstration using a front end deployed with serverless-finch and a backend. | nodeJS |
 | [Aws Env Variables Encrypted In A File](https://github.com/serverless/examples/tree/master/aws-node-env-variables-encrypted-in-a-file) <br/> Serverless example managing secrets in an encrypted file | nodeJS |
 | [Aws Env Variables](https://github.com/serverless/examples/tree/master/aws-node-env-variables) <br/> This example demonstrates how to use environment variables for AWS Lambdas. | nodeJS |
 | [Aws Fetch File And Store In S3](https://github.com/serverless/examples/tree/master/aws-node-fetch-file-and-store-in-s3) <br/> Fetch an image from remote source (URL) and then upload the image to a S3 bucket. | nodeJS |
+| [Sfe Demo Leadcapture](https://github.com/serverless/examples/tree/master/aws-node-fullstack/backend)  | nodeJS |
+| [Frontend](https://github.com/serverless/examples/tree/master/aws-node-fullstack/frontend)  | nodeJS |
 | [Aws Function Compiled With Babel](https://github.com/serverless/examples/tree/master/aws-node-function-compiled-with-babel) <br/> Demonstrating how to compile all your code with Babel | nodeJS |
 | [Serverless Github Check](https://github.com/serverless/examples/tree/master/aws-node-github-check)  | nodeJS |
 | [Aws Github Webhook Listener](https://github.com/serverless/examples/tree/master/aws-node-github-webhook-listener) <br/> Extend your github repositories with this github webhook listener | nodeJS |

--- a/aws-node-puppeteer/serverless.yml
+++ b/aws-node-puppeteer/serverless.yml
@@ -16,7 +16,7 @@ functions:
   hello:
     handler: handler.hello
     memorySize: 1536MB
-    timeout: 60
+    timeout: 30
     events:
       - http:
           path: /


### PR DESCRIPTION
Is this correct? I get a warning from Serverless that the max timeout API Gateway and the Serverless config are not the same.

```
Serverless: WARNING: Function crawl has timeout of 60 seconds, however, it's attached to API Gateway so it's automatically limited to 30 seconds.
```

<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->