### PR TITLE
Update Node runtime to 10.x from 6.x (no longer supported)

### DIFF
--- a/aws-node-graphql-api-with-dynamodb/serverless.yml
+++ b/aws-node-graphql-api-with-dynamodb/serverless.yml
@@ -2,7 +2,7 @@ service: graphql-api
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   environment:
     DYNAMODB_TABLE: ${self:service}-${self:provider.stage}
   iamRoleStatements:


### PR DESCRIPTION
Lambda no longer support Node 6.x - updated the serverless.yml with the latest supported runtime - 10.x

