### PR TITLE
Use DynamoDB On-Demand

### DIFF
--- a/aws-node-rest-api-with-dynamodb-and-offline/serverless.yml
+++ b/aws-node-rest-api-with-dynamodb-and-offline/serverless.yml
@@ -86,7 +86,5 @@ resources:
           -
             AttributeName: id
             KeyType: HASH
-        ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+        BillingMode: PAY_PER_REQUEST
         TableName: ${self:provider.environment.DYNAMODB_TABLE}


### PR DESCRIPTION
A Serverless, pay-per-use makes more sense in this scenario, and would spare the user from paying for unused provisioned resources. See https://serverless.com/blog/dynamodb-on-demand-serverless/