### PR TITLE
upgrade to python 3.8 to fix timestamp bug

### DIFF
--- a/aws-python-rest-api-with-dynamodb/serverless.yml
+++ b/aws-python-rest-api-with-dynamodb/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: ">=1.1.0 <2.0.0"
 
 provider:
   name: aws
-  runtime: python2.7
+  runtime: python3.8
   environment:
     DYNAMODB_TABLE: ${self:service}-${opt:stage, self:provider.stage}
   iamRoleStatements:


### PR DESCRIPTION
This PR concerns the "aws-python-rest-api-with-dynamodb" example.

The commit `45bd5ee1a975735783565a6e48259f293d5e42cd` inserted a regression and generate the following error: "AttributeError: 'datetime.datetime' object has no attribute 'timestamp'".

Indeed, the example was written in python 2.7 but datetime.timestamp() is only available from python 3.3 and later.

I upgraded and tested it successfully in Python 3.8.