### PR TITLE
fix: bump pynamodb to 4.3.1

### DIFF
--- a/aws-python-rest-api-with-pynamodb/requirements.txt
+++ b/aws-python-rest-api-with-pynamodb/requirements.txt
@@ -1,3 +1,3 @@
-pynamodb==3.1.0
+pynamodb==4.3.1
 boto3 #no-deploy
 botocore #no-deploy


### PR DESCRIPTION
previous versions were using vendored "requests" from botocore, which is deprecated

<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->