### PR TITLE
Update Node.js runtime to 12.x

### DIFF
--- a/aws-node-graphql-and-rds/serverless.yml
+++ b/aws-node-graphql-and-rds/serverless.yml
@@ -5,7 +5,7 @@ provider:
   region: us-east-1
   stage: dev
   memorySize: 256
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   role: LambdaRole
   environment:
     #aurora


### PR DESCRIPTION
Node.js 8.10 has reached its end of life on Lambda, therefore this boilerplate no longer works. This PR bumps the environment to Node.js 12.x
<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->