### PR TITLE
Update node runtime to 12.x

### DIFF
--- a/aws-node-scheduled-cron/serverless.yml
+++ b/aws-node-scheduled-cron/serverless.yml
@@ -2,7 +2,7 @@ service: scheduled-cron-example
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
 
 functions:
   cron:


### PR DESCRIPTION
To fix error returned from AWS after `serverless deploy`
> The runtime parameter of nodejs8.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs12.x) while creating or updating functions