### PR TITLE
chore: remove cors: true from the authorizer

### DIFF
--- a/aws-node-auth0-custom-authorizers-api/serverless.yml
+++ b/aws-node-auth0-custom-authorizers-api/serverless.yml
@@ -15,7 +15,6 @@ provider:
 functions:
   auth:
     handler: handler.auth
-    cors: true
   publicEndpoint:
     handler: handler.publicEndpoint
     events:


### PR DESCRIPTION
It seems to me that it makes little sense to specify `cors: true` outside of the HTTP Event configuration

Linter: not needed, just YAML changes.