### PR TITLE
Updated aws-node-upload-to-s3-and-postprocess with AWS4-HMAC-SHA256

### DIFF
--- a/aws-node-upload-to-s3-and-postprocess/README.md
+++ b/aws-node-upload-to-s3-and-postprocess/README.md
@@ -23,10 +23,12 @@ trigger a lambda function.
 - Edit `serverless.yml` and choose a unique S3 bucket name.
 - Edit `generate-form.js` and fill in your `aws_access_key_id`,
   `aws_secret_access_key` and `bucket_name`.
+- Run `yarn install` to install crypto-js dependency for `generate-form.js`.
 - Generate the HTML form:
 
 
 ```bash
+yarn install
 node generate-form.js
 ```
 

--- a/aws-node-upload-to-s3-and-postprocess/frontend/index.template.html
+++ b/aws-node-upload-to-s3-and-postprocess/frontend/index.template.html
@@ -6,12 +6,14 @@
 
   <body>
     <form action="%BUCKET_URL%" method="post" enctype="multipart/form-data">
-      <input type="hidden" name="Content-Type" value="image/png">
-      <input type="hidden" name="AWSAccessKeyId" value="%AWS_ACCESS_KEY%">
       <input type="hidden" name="acl" value="public-read">
+      <input type="hidden" name="Content-Type" value="image/png">
+      <input type="hidden" name="x-amz-credential" value="%CREDENTIAL%">
+      <input type="hidden" name="x-amz-algorithm" value="AWS4-HMAC-SHA256">
+      <input type="hidden" name="x-amz-date" value="%DATE%">
       <input type="hidden" name="success_action_status" value="201">
-      <input type="hidden" name="policy" value="%POLICY_BASE64%">
-      <input type="hidden" name="signature" value="%SIGNATURE%">
+      <input type="hidden" name="Policy" value="%POLICY_BASE64%">
+      <input type="hidden" name="x-amz-signature" value="%SIGNATURE%">
 
       Destination filename: <input type="text" name="key" value="uploads/image.png">
       <br>

--- a/aws-node-upload-to-s3-and-postprocess/generate-form.js
+++ b/aws-node-upload-to-s3-and-postprocess/generate-form.js
@@ -1,33 +1,51 @@
 #!/usr/bin/env node
 
-const crypto = require('crypto');
+const crypto = require('crypto-js');
+const Hex = require('crypto-js/enc-hex');
 const fs = require('fs');
+
+// from: https://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html#signature-v4-examples-javascript
+function getSignatureKey(key, dateStamp, regionName, serviceName) {
+  const kDate = crypto.HmacSHA256(dateStamp, `AWS4${key}`);
+  const kRegion = crypto.HmacSHA256(regionName, kDate);
+  const kService = crypto.HmacSHA256(serviceName, kRegion);
+  const kSigning = crypto.HmacSHA256('aws4_request', kService);
+  return kSigning;
+}
 
 const awsAccessKeyId = '<your access key id>';
 const awsSecretAccessKey = '<your secret access key>';
 const bucketName = '<your bucket name>';
+const region = '<your region name>';
 
 const msPerDay = 24 * 60 * 60 * 1000;
 const expiration = new Date(Date.now() + msPerDay).toISOString();
 const bucketUrl = `https://${bucketName}.s3.amazonaws.com`;
+const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+const credentials = `${awsAccessKeyId}/${date}/${region}/s3/aws4_request`;
 
+// Sample policy and form: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
 const policy = {
   expiration,
   conditions: [
-    ['starts-with', '$key', 'uploads/'],
     { bucket: bucketName },
+    ['starts-with', '$key', 'uploads/'],
     { acl: 'public-read' },
     ['starts-with', '$Content-Type', 'image/png'],
-    { success_action_status: '201' },
+    // ['starts-with', '$success_action_redirect', ''],
+    ['starts-with', '$success_action_status', ''],
+
+    { 'x-amz-credential': credentials },
+    { 'x-amz-algorithm': 'AWS4-HMAC-SHA256' },
+    { 'x-amz-date': `${date}T000000Z` },
   ],
 };
 
-const policyB64 = Buffer(JSON.stringify(policy), 'utf-8').toString('base64');
+const policyB64 = Buffer.from(JSON.stringify(policy), 'utf-8').toString('base64');
 
-const hmac = crypto.createHmac('sha1', awsSecretAccessKey);
-hmac.update(new Buffer(policyB64, 'utf-8'));
+const sigKey = getSignatureKey(awsSecretAccessKey, date, region, 's3');
 
-const signature = hmac.digest('base64');
+const signature = Hex.stringify(crypto.HmacSHA256(policyB64, sigKey));
 
 fs.readFile('frontend/index.template.html', 'utf8', (err, input) => {
   if (err) {
@@ -36,8 +54,9 @@ fs.readFile('frontend/index.template.html', 'utf8', (err, input) => {
 
   const data = input
     .replace(/%BUCKET_URL%/g, bucketUrl)
-    .replace(/%AWS_ACCESS_KEY%/g, awsAccessKeyId)
     .replace(/%POLICY_BASE64%/g, policyB64)
+    .replace(/%CREDENTIAL%/g, credentials)
+    .replace(/%DATE%/g, `${date}T000000Z`)
     .replace(/%SIGNATURE%/g, signature);
 
   fs.writeFile('frontend/index.html', data, 'utf8', (e) => {

--- a/aws-node-upload-to-s3-and-postprocess/package.json
+++ b/aws-node-upload-to-s3-and-postprocess/package.json
@@ -5,5 +5,6 @@
   "author": "Christoph Gysin <christoph.gysin@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "crypto-js": "^4.0.0"
   }
 }


### PR DESCRIPTION
Updated aws-node-upload-to-s3-and-postprocess example to use signing key with AWS Signature Version 4 (AWS4-HMAC-SHA256)