### PR TITLE
return successfully saved data

### DIFF
--- a/aws-node-typescript-rest-api-with-dynamodb/todos/create.ts
+++ b/aws-node-typescript-rest-api-with-dynamodb/todos/create.ts
@@ -38,7 +38,7 @@ module.exports.create = (event, context, callback) => {
     // create a response
     const response = {
       statusCode: 200,
-      body: JSON.stringify(result.Item)
+      body: JSON.stringify(params.Item)
     }
     callback(null, response)
   })


### PR DESCRIPTION
The `result` variable doesn't contain any data for a DynamoDB Put op. So return `params.Item` instead, like in the non-TypeScript version.