### PR TITLE
update the version of Serverless Framework

### DIFF
--- a/aws-python-rest-api-with-dynamodb/serverless.yml
+++ b/aws-python-rest-api-with-dynamodb/serverless.yml
@@ -1,6 +1,6 @@
 service: serverless-rest-api-with-dynamodb
 
-frameworkVersion: ">=1.1.0 <2.0.0"
+frameworkVersion: ">=1.1.0 <=2.1.1"
 
 provider:
   name: aws


### PR DESCRIPTION
The current version of Serverless Framework is 2.1.1 and the specified is 2.0.0.
Due to this it will raise you the following error: The Serverless version (2.1.1) does not satisfy the "frameworkVersion" (>=1.1.0 <2.0.0) in serverless.yml