### PR TITLE
Serverless REST API with DynamoDB and offline support: optional persistent docker dynamodb setup

### DIFF
--- a/aws-node-rest-api-with-dynamodb-and-offline/README.md
+++ b/aws-node-rest-api-with-dynamodb-and-offline/README.md
@@ -27,7 +27,7 @@ Test your service locally, without having to deploy it first.
 
 ```bash
 npm install
-serverless dynamodb install
+serverless dynamodb install (or to use a persistent docker dynamodb instead, open a new terminal: cd ./dynamodb && docker-compose up -d)
 serverless offline start
 serverless dynamodb migrate (this imports schema)
 ```

--- a/aws-node-rest-api-with-dynamodb-and-offline/dynamodb/Dockerfile
+++ b/aws-node-rest-api-with-dynamodb-and-offline/dynamodb/Dockerfile
@@ -1,0 +1,8 @@
+FROM amazon/dynamodb-local
+
+WORKDIR /home/dynamodblocal
+
+RUN mkdir ./db && chown -R 1000 ./db
+
+CMD ["-jar", "DynamoDBLocal.jar", "-dbPath", "./db", "-sharedDb"]
+VOLUME ["./db"]

--- a/aws-node-rest-api-with-dynamodb-and-offline/dynamodb/docker-compose.yml
+++ b/aws-node-rest-api-with-dynamodb-and-offline/dynamodb/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+
+services:
+  dynamodb:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8000:8000
+    volumes:
+      - aws-rest-api-dynamodb:/home/dynamodblocal/db
+
+volumes:
+  aws-rest-api-dynamodb:
+    driver: local

--- a/aws-node-rest-api-with-dynamodb-and-offline/package.json
+++ b/aws-node-rest-api-with-dynamodb-and-offline/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "aws-sdk": "^2.12.0",
     "serverless-dynamodb-local": "^0.2.18",
-    "serverless-offline": "^3.8.3"
+    "serverless-offline": "^6.8.0"
   }
 }

--- a/aws-node-rest-api-with-dynamodb-and-offline/serverless.yml
+++ b/aws-node-rest-api-with-dynamodb-and-offline/serverless.yml
@@ -14,6 +14,8 @@ custom:
       port: 8000
       inMemory: true
       migrate: true
+    # Comment if you don't have a DynamoDB running locally
+      noStart: true
     migration:
       dir: offline/migrations
 

--- a/aws-node-rest-api-with-dynamodb-and-offline/serverless.yml
+++ b/aws-node-rest-api-with-dynamodb-and-offline/serverless.yml
@@ -1,6 +1,6 @@
 service: serverless-rest-api-with-dynamodb
 
-frameworkVersion: ">=1.1.0 <2.0.0"
+frameworkVersion: ">=1.1.0 <=2.4.0"
 
 plugins:
   - serverless-dynamodb-local


### PR DESCRIPTION
[Serverless REST API with DynamoDB and offline support](https://github.com/serverless/examples/tree/master/aws-node-rest-api-with-dynamodb-and-offline): Adds optional persistent docker dynamodb setup for development and testing.