### PR TITLE
fix: Add missing template for `aws-python-flask-api`

### DIFF
--- a/aws-python-flask-api/serverless.template.yml
+++ b/aws-python-flask-api/serverless.template.yml
@@ -1,0 +1,6 @@
+name: aws-python-flask-api
+org: serverlessinc
+description: Deploys a Python Flask API service with traditional Serverless Framework
+keywords: aws, serverless, faas, lambda, python, flask
+repo: https://github.com/serverless/examples/aws-python-flask-api
+license: MIT

--- a/aws-python-flask-dynamodb-api/serverless.template.yml
+++ b/aws-python-flask-dynamodb-api/serverless.template.yml
@@ -1,0 +1,6 @@
+name: aws-python-flask-dynamodb-api
+org: serverlessinc
+description: Deploys a Python Flask API service, backed by DynamoDB, with traditional Serverless Framework
+keywords: aws, serverless, faas, lambda, python, flask, dynamodb
+repo: https://github.com/serverless/examples/aws-python-flask-dynamodb-api
+license: MIT


### PR DESCRIPTION
Adds missing `serverless.template.yml` files for Flask-based examples