### PR TITLE
fix: Use `Ref:` instead of `!Ref` in `sqs` templates

### DIFF
--- a/aws-node-sqs-worker/serverless.yml
+++ b/aws-node-sqs-worker/serverless.yml
@@ -29,7 +29,8 @@ functions:
           method: post
           path: produce
     environment:
-      QUEUE_URL: !Ref WorkerQueue
+      QUEUE_URL:
+        Ref: WorkerQueue
 
   consumer:
     handler: handler.consumer

--- a/aws-python-sqs-worker/serverless.yml
+++ b/aws-python-sqs-worker/serverless.yml
@@ -29,7 +29,8 @@ functions:
           method: post
           path: produce
     environment:
-      QUEUE_URL: !Ref WorkerQueue
+      QUEUE_URL:
+        Ref: WorkerQueue
 
   consumer:
     handler: handler.consumer


### PR DESCRIPTION
It turned out that `sls publish` does not support publishing templates with `!Ref` reference - it works fine with `Ref:` though, hence the following change. 