### PR TITLE
Add async to handler in order to end function

### DIFF
--- a/aws-node-scheduled-cron/handler.js
+++ b/aws-node-scheduled-cron/handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports.run = (event, context) => {
+module.exports.run = async (event, context) => {
   const time = new Date();
   console.log(`Your cron function "${context.functionName}" ran at ${time}`);
 };


### PR DESCRIPTION
Since there is no callback and there function is not async the enterprise-plugin will not write a log to CloudWatch.

<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->