### PR TITLE
Update aws-python-flask-api README.md to include pip install

### DIFF
--- a/aws-python-flask-api/README.md
+++ b/aws-python-flask-api/README.md
@@ -48,6 +48,12 @@ install dependencies with:
 npm install
 ```
 
+and
+
+```
+pip install -r requirements.txt
+```
+
 and then perform deployment with:
 
 ```


### PR DESCRIPTION
Without running pip install, I ran into the following error in CloudWatch.

```
Runtime.HandlerNotFound: Handler 'handler' missing on module 'wsgi_handler'
```