### PR TITLE
refactor: Remove `org` and `app` from selected templates

### DIFF
--- a/aws-node-rest-api/serverless.yml
+++ b/aws-node-rest-api/serverless.yml
@@ -1,5 +1,3 @@
-org: serverlessinc
-app: aws-node-rest-api
 service: aws-node-rest-api
 
 frameworkVersion: '2'

--- a/aws-python-rest-api/serverless.yml
+++ b/aws-python-rest-api/serverless.yml
@@ -1,5 +1,3 @@
-org: serverlessinc
-app: aws-python-rest-api
 service: aws-python-rest-api
 
 frameworkVersion: '2'


### PR DESCRIPTION
Remove `org` and `app` to not cause issues when using these templates with interactive flow