### PR TITLE
chore: Update `ruby` runtime from 2.5 to 2.7

### DIFF
--- a/aws-ruby-line-bot/serverless.yml
+++ b/aws-ruby-line-bot/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: ">=2.1.0 <3.0.0"
 
 provider:
   name: aws
-  runtime: ruby2.5
+  runtime: ruby2.7
 
 functions:
   webhook:

--- a/aws-ruby-simple-http-endpoint/serverless.yml
+++ b/aws-ruby-simple-http-endpoint/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: ">=2.1.0 <3.0.0"
 
 provider:
   name: aws
-  runtime: ruby2.5
+  runtime: ruby2.7
 
 functions:
   current_time:


### PR DESCRIPTION
# Background

On July 30, 2021, there will be the first phase of the end of support for AWS Lambda Ruby 2.5 runtime (https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html).

Within the `examples` there are only two projects, which have `ruby2.5` runtime:

- [aws-ruby-line-bot](https://github.com/serverless/examples/tree/master/aws-ruby-line-bot)
-  [aws-ruby-simple-http-endpoint](https://github.com/serverless/examples/tree/master/aws-ruby-simple-http-endpoint)

# Solution

The solution is pretty easy, simple I've updated the runtime from `2.5` to `2.7` for those two projects.

 It is always good to have up-to-date examples of projects.