### PR TITLE
fix: Update dependencies for Python Flask for Lambda compatibility

### DIFF
--- a/aws-python-flask-api/requirements.txt
+++ b/aws-python-flask-api/requirements.txt
@@ -1,1 +1,3 @@
-Flask==1.1.2
+Flask==1.1.4
+Werkzeug==1.0.1
+

--- a/aws-python-flask-dynamodb-api/requirements.txt
+++ b/aws-python-flask-dynamodb-api/requirements.txt
@@ -1,1 +1,3 @@
-Flask==1.1.2
+Flask==1.1.4
+Werkzeug==1.0.1
+


### PR DESCRIPTION
Update `Flask` and explicitly lock `Werkzeug` version as recently released `Werkzeug` in `v2` is not compatible with Lambda runtime.