### PR TITLE
fix: Update `runtime` for `openwhisk-python-simple` example.

### DIFF
--- a/openwhisk-python-simple/serverless.yml
+++ b/openwhisk-python-simple/serverless.yml
@@ -2,7 +2,7 @@ service: python-service
 
 provider:
   name: openwhisk
-  runtime: python
+  runtime: python:3
 
 functions:
   greeting:


### PR DESCRIPTION
Deploying with previous code results in this error: 

Failed to deploy function (openwhisk-python-simple-dev-greeting) due to error: PUT https://eu-gb.functions.cloud.ibm.com/api/v1/namespaces/_/actions/openwhisk-python-simple-dev-greeting?overwrite=true Returned HTTP 400 (Bad Request) --> "The 'python' runtime is no longer supported. You may read and delete but not update or invoke this action."

<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->