### PR TITLE
fix: Ensure to use `amd64` arch for `golang` examples

### DIFF
--- a/aws-golang-auth-examples/Makefile
+++ b/aws-golang-auth-examples/Makefile
@@ -5,5 +5,5 @@ functions := $(shell find functions -name \*main.go | awk -F'/' '{print $$2}')
 
 build: ## Build golang binaries
 	@for function in $(functions) ; do \
-		env GOOS=linux go build -ldflags="-s -w" -o bin/$$function functions/$$function/main.go ; \
+		env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/$$function functions/$$function/main.go ; \
 	done

--- a/aws-golang-dynamo-stream-to-elasticsearch/Makefile
+++ b/aws-golang-dynamo-stream-to-elasticsearch/Makefile
@@ -1,6 +1,6 @@
 build:
 	dep ensure -v
-	env GOOS=linux go build -ldflags="-s -w" -o bin/aws-golang-dynamo-stream-to-elasticsearch cmd/aws-golang-dynamo-stream-to-elasticsearch/main.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/aws-golang-dynamo-stream-to-elasticsearch cmd/aws-golang-dynamo-stream-to-elasticsearch/main.go
 
 .PHONY: clean
 clean:

--- a/aws-golang-googlemap/Makefile
+++ b/aws-golang-googlemap/Makefile
@@ -2,10 +2,10 @@
 
 build:
 	dep ensure -v
-	env GOOS=linux go build -ldflags="-s -w" -o bin/getgeolocation getgeolocation/main.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/getsearchlocation getsearchlocation/main.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/getnearbylocation getnearbylocation/main.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/getgeodetail getgeodetail/main.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/getgeolocation getgeolocation/main.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/getsearchlocation getsearchlocation/main.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/getnearbylocation getnearbylocation/main.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/getgeodetail getgeodetail/main.go
 
 clean:
 	rm -rf ./bin ./vendor Gopkg.lock

--- a/aws-golang-http-get-post/Makefile
+++ b/aws-golang-http-get-post/Makefile
@@ -2,9 +2,9 @@
 
 build:
 	dep ensure -v
-	env GOOS=linux go build -ldflags="-s -w" -o bin/getBin getFolder/getExample.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/postBin postFolder/postExample.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/getQueryBin getFolder/getQueryExample.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/getBin getFolder/getExample.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/postBin postFolder/postExample.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/getQueryBin getFolder/getQueryExample.go
 
 clean:
 	rm -rf ./bin ./vendor Gopkg.lock

--- a/aws-golang-s3-file-replicator/Makefile
+++ b/aws-golang-s3-file-replicator/Makefile
@@ -2,7 +2,7 @@
 
 build: gomodgen
 	export GO111MODULE=on
-	env GOOS=linux go build -ldflags="-s -w" -o bin/replicator src/main.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/replicator src/main.go
 
 clean:
 	rm -rf ./bin ./vendor Gopkg.lock

--- a/aws-golang-simple-http-endpoint/Makefile
+++ b/aws-golang-simple-http-endpoint/Makefile
@@ -1,7 +1,7 @@
 build:
 	dep ensure -v
-	env GOOS=linux go build -ldflags="-s -w" -o bin/hello hello/main.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/world world/main.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/hello hello/main.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/world world/main.go
 
 .PHONY: clean
 clean:

--- a/aws-golang-stream-kinesis-to-elasticsearch/Makefile
+++ b/aws-golang-stream-kinesis-to-elasticsearch/Makefile
@@ -1,6 +1,6 @@
 build:
 	dep ensure -v
-	env GOOS=linux go build -ldflags="-s -w" -o bin/stream main.go
+	env GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -o bin/stream main.go
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Related to: https://github.com/serverless/serverless/pull/9646