### PR TITLE
fix: Update `runtime` for `openwhisk-python-*` examples

### DIFF
--- a/openwhisk-python-scheduled-cron/serverless.yml
+++ b/openwhisk-python-scheduled-cron/serverless.yml
@@ -2,7 +2,7 @@ service: python_service
 
 provider:
   name: openwhisk
-  runtime: python
+  runtime: python:3
 
 functions:
   cron:

--- a/openwhisk-python-simple-http-endpoint/serverless.yml
+++ b/openwhisk-python-simple-http-endpoint/serverless.yml
@@ -2,7 +2,7 @@ service: python-service
 
 provider:
   name: openwhisk
-  runtime: python
+  runtime: python:3
 
 functions:
   currentTime:


### PR DESCRIPTION
Related to: https://github.com/serverless/examples/pull/627