### PR TITLE
fix: `lodash` dependency for `twilio` example

### DIFF
--- a/aws-node-twilio-send-text-message/README.md
+++ b/aws-node-twilio-send-text-message/README.md
@@ -30,27 +30,37 @@ This example demonstrates how to send SMS messages with the Twilio SDK and AWS l
 
 4. Set your `env` variables in `serverless.yml` with your Twilio account values
 
-  ```yml
-  environment:
-    # replace these env variables with your twilio account values
-    TWILIO_ACCOUNT_SID: YOUR-TWILIO-ACCOUNT-SID-HERE
-    TWILIO_AUTH_TOKEN: YOUR-TWILIO-AUTH-TOKEN-HERE
-    TWILIO_PHONE_NUMBER: YOUR-TWILIO-PHONE-NUMBER-HERE
-  ```
+      ```yml
+      environment:
+        # replace these env variables with your twilio account values
+        TWILIO_ACCOUNT_SID: YOUR-TWILIO-ACCOUNT-SID-HERE
+        TWILIO_AUTH_TOKEN: YOUR-TWILIO-AUTH-TOKEN-HERE
+        TWILIO_PHONE_NUMBER: YOUR-TWILIO-PHONE-NUMBER-HERE
+      ```
+    
+      If you want to use encrypted API keys, see our [encrypted environment variables example](https://github.com/serverless/examples/tree/master/aws-node-env-variables-encrypted-in-a-file)
+      
+5. Install the dependencies required by the service 
+      ```bash
+      npm i --only=prod
+      ```
+      
+6. Deploy the service 
+      ```bash
+      serverless deploy
+      ```
 
-  If you want to use encrypted API keys, see our [encrypted environment variables example](https://github.com/serverless/examples/tree/master/aws-node-env-variables-encrypted-in-a-file)
+7. Invoke the function and send an SMS message
 
-5. Invoke the function and send an SMS message
+      Update the `to` phone number the `event.json` file and `message` to send in the SMS
+    
+      Then invoke the function with the serverless CLI. Set the `--path event.json` so the function knows where to send the SMS.
+    
+      ```bash
+      serverless invoke -f sendText --path event.json
+      ```
 
-  Update the `to` phone number the `event.json` file and `message` to send in the SMS
-
-  Then invoke the function with the serverless CLI. Set the `--path event.json` so the function knows where to send the SMS.
-
-  ```bash
-  serverless invoke -f sendText --path event.json
-  ```
-
-6. (Optional) Deploy the front-end application
+8. (Optional) Deploy the front-end application
 
   Update the `API_ENDPOINT` variable in the `/frontend/index.html` file and deploy the `/frontend` folder to a static host of your choice.
 

--- a/aws-node-twilio-send-text-message/package.json
+++ b/aws-node-twilio-send-text-message/package.json
@@ -9,11 +9,11 @@
   "author": "David Wells",
   "license": "MIT",
   "dependencies": {
-    "twilio": "^2.11.1"
+    "twilio": "^3.65.0"
   },
   "devDependencies": {
     "chai": "^4.0.0",
-    "mocha": "^3.4.2",
+    "mocha": "^9.0.2",
     "sinon": "^2.3.2"
   }
 }

--- a/aws-node-twilio-send-text-message/serverless.yml
+++ b/aws-node-twilio-send-text-message/serverless.yml
@@ -12,7 +12,6 @@ provider:
 package:
   exclude:
     - "*.test.js"
-    - 'node_modules/**'
     - '!node_modules/twilio/**'
     - 'frontend/**'
 

--- a/aws-node-twilio-send-text-message/serverless.yml
+++ b/aws-node-twilio-send-text-message/serverless.yml
@@ -12,7 +12,6 @@ provider:
 package:
   exclude:
     - "*.test.js"
-    - '!node_modules/twilio/**'
     - 'frontend/**'
 
 functions:


### PR DESCRIPTION
Fix for the lodash dependency error with the Twilio example.

Several problems, there was an error occurring with the previous Twilio version.

* Twilio v2.11.1 was causing an import module error.  (Upgraded to 3.65.0)
* Twilio v3.65.0 was causing the error in Issue #622 

Fixes:
* Updated Mocha to v9.0.2 (fixes critical errors)
* Removed node_modules exclusion line in `serverless.yml` and replaced with extra `npm i --only=prod` step in the README

All unit tests pass, Twilio successfully sends SMS message.