### PR TITLE
feat: Add missing `serverless.template.yml`

### DIFF
--- a/aws-node-http-api-typescript/serverless.template.yml
+++ b/aws-node-http-api-typescript/serverless.template.yml
@@ -1,0 +1,6 @@
+name: aws-node-http-api-typescript
+org: serverlessinc
+description: Deploys a Node HTTP API service with Serverless Framework and Typescript
+keywords: aws, serverless, faas, lambda, node, typescript
+repo: https://github.com/serverless/examples/aws-node-http-api-typescript
+license: MIT


### PR DESCRIPTION
Add missing `serverless.template.yml`, it is needed in order to publish template to be used in app.serverless.com