### PR TITLE
Change dbInstanceClass for postgres to small to be compatible with postgres 13.3

### DIFF
--- a/aws-node-graphql-and-rds/resource/PostgreSqlRDSInstance.yml
+++ b/aws-node-graphql-and-rds/resource/PostgreSqlRDSInstance.yml
@@ -5,7 +5,7 @@ Properties:
   MasterUserPassword: ${self:custom.PASSWORD}
   AllocatedStorage: 20
   DBName: ${self:custom.DB_NAME}
-  DBInstanceClass: db.t2.micro
+  DBInstanceClass: db.t4g.small
   VPCSecurityGroups:
   - !GetAtt ServerlessSecurityGroup.GroupId
   DBSubnetGroupName:


### PR DESCRIPTION
db.t2.micro is not compatible with postgres 13.3
Running the following command shows support for micro stops at 12.8
```
aws rds describe-orderable-db-instance-options --engine postgres --db-instance-class db.t2.micro \
    --query "*[].{EngineVersion:EngineVersion,StorageType:StorageType}|[?StorageType=='gp2']|[].{EngineVersion:EngineVersion}" \
    --output text \
    --region us-east-1
```