### PR TITLE
fix: Chang `/ping` path to `/time` in several examples

### DIFF
--- a/aws-java-simple-http-endpoint/README.md
+++ b/aws-java-simple-http-endpoint/README.md
@@ -1,6 +1,6 @@
 <!--
 title: 'AWS Simple HTTP Endpoint example in Java'
-description: 'This example demonstrates how to setup a simple HTTP GET endpoint using Java. Once you ping it, it will reply with the current time.'
+description: 'This example demonstrates how to setup a simple HTTP GET endpoint using Java. Once you fetch it, it will reply with the current time.'
 layout: Doc
 framework: v1
 platform: AWS
@@ -12,7 +12,7 @@ authorAvatar: 'https://avatars3.githubusercontent.com/u/1767769?v=4&s=140'
 -->
 # Simple HTTP Endpoint Example
 
-This example demonstrates how to setup a simple HTTP GET endpoint using Java. Once you ping it, it will reply with the current time.
+This example demonstrates how to setup a simple HTTP GET endpoint using Java. Once you fetch it, it will reply with the current time.
 
 [Jackson](https://github.com/FasterXML/jackson) is used to serialize objects to JSON.
 
@@ -110,7 +110,7 @@ region: us-east-1
 api keys:
   None
 endpoints:
-  GET - https://XXXXXXX.execute-api.us-east-1.amazonaws.com/ping
+  GET - https://XXXXXXX.execute-api.us-east-1.amazonaws.com/time
 functions:
   aws-java-simple-http-endpoint-dev-currentTime: arn:aws:lambda:us-east-1:XXXXXXX:function:aws-java-simple-http-endpoint-dev-currentTime
 
@@ -146,7 +146,7 @@ REPORT RequestId: XXXXXXX	Duration: 0.51 ms	Billed Duration: 100 ms 	Memory Size
 Finally you can send an HTTP request directly to the endpoint using a tool like curl
 
 ```bash
-curl https://XXXXXXX.execute-api.us-east-1.amazonaws.com/ping
+curl https://XXXXXXX.execute-api.us-east-1.amazonaws.com/time
 ```
 
 The expected result should be similar to:

--- a/aws-java-simple-http-endpoint/serverless.yml
+++ b/aws-java-simple-http-endpoint/serverless.yml
@@ -13,5 +13,5 @@ functions:
     handler: com.serverless.Handler
     events:
       - httpApi:
-          path: /ping
+          path: /time
           method: get

--- a/aws-node-simple-http-endpoint/README.md
+++ b/aws-node-simple-http-endpoint/README.md
@@ -1,6 +1,6 @@
 <!--
 title: 'AWS Simple HTTP Endpoint example in NodeJS'
-description: 'This example demonstrates how to setup a simple HTTP GET endpoint. Once you ping it, it will reply with the current time.'
+description: 'This example demonstrates how to setup a simple HTTP GET endpoint. Once you fetch it, it will reply with the current time.'
 layout: Doc
 framework: v1
 platform: AWS
@@ -12,7 +12,7 @@ authorAvatar: 'https://avatars0.githubusercontent.com/u/8188?v=4&s=140'
 -->
 # Simple HTTP Endpoint Example
 
-This example demonstrates how to setup a simple HTTP GET endpoint. Once you ping it, it will reply with the current time. While the internal function is name `currentTime` the HTTP endpoint is exposed as `ping`.
+This example demonstrates how to setup a simple HTTP GET endpoint. Once you fetch it, it will reply with the current time. While the internal function is name `currentTime` the HTTP endpoint is exposed as `time`.
 
 ## Use Cases
 
@@ -61,7 +61,7 @@ region: us-east-1
 api keys:
   None
 endpoints:
-  GET - https://2e16njizla.execute-api.us-east-1.amazonaws.com/ping
+  GET - https://2e16njizla.execute-api.us-east-1.amazonaws.com/time
 functions:
   serverless-simple-http-endpoint-dev-currentTime: arn:aws:lambda:us-east-1:488110005556:function:serverless-simple-http-endpoint-dev-currentTime
 ```
@@ -77,7 +77,7 @@ serverless invoke --function currentTime --log
 or as send an HTTP request directly to the endpoint using a tool like curl
 
 ```bash
-curl https://XXXXXXX.execute-api.us-east-1.amazonaws.com/ping
+curl https://XXXXXXX.execute-api.us-east-1.amazonaws.com/time
 ```
 
 ## Scaling

--- a/aws-node-simple-http-endpoint/serverless.yml
+++ b/aws-node-simple-http-endpoint/serverless.yml
@@ -10,5 +10,5 @@ functions:
     handler: handler.endpoint
     events:
       - httpApi:
-          path: /ping
+          path: /time
           method: get

--- a/aws-python-simple-http-endpoint/README.md
+++ b/aws-python-simple-http-endpoint/README.md
@@ -1,6 +1,6 @@
 <!--
 title: 'AWS Simple HTTP Endpoint example in Python'
-description: 'This example demonstrates how to setup a simple HTTP GET endpoint. Once you ping it, it will reply with the current time.'
+description: 'This example demonstrates how to setup a simple HTTP GET endpoint. Once you fetch it, it will reply with the current time.'
 layout: Doc
 framework: v1
 platform: AWS
@@ -12,7 +12,7 @@ authorAvatar: 'https://avatars0.githubusercontent.com/u/8188?v=4&s=140'
 -->
 # Simple HTTP Endpoint Example
 
-This example demonstrates how to setup a simple HTTP GET endpoint. Once you ping it, it will reply with the current time. While the internal function is name `currentTime` the HTTP endpoint is exposed as `ping`.
+This example demonstrates how to setup a simple HTTP GET endpoint. Once you fetch it, it will reply with the current time. While the internal function is name `currentTime` the HTTP endpoint is exposed as `time`.
 
 ## Use Cases
 
@@ -42,7 +42,7 @@ region: us-east-1
 api keys:
   None
 endpoints:
-  GET - https://f7r5srabr3.execute-api.us-east-1.amazonaws.com/ping
+  GET - https://f7r5srabr3.execute-api.us-east-1.amazonaws.com/time
 functions:
   currentTime: aws-python-simple-http-endpoint-dev-currentTime
 ```
@@ -71,7 +71,7 @@ REPORT RequestId: a26699d3-b3ee-11e6-98f33f952e8294	Duration: 0.23 ms	Billed Dur
 Finally you can send an HTTP request directly to the endpoint using a tool like curl
 
 ```bash
-curl https://XXXXXXX.execute-api.us-east-1.amazonaws.com/ping
+curl https://XXXXXXX.execute-api.us-east-1.amazonaws.com/time
 ```
 
 The expected result should be similar to:

--- a/aws-python-simple-http-endpoint/serverless.yml
+++ b/aws-python-simple-http-endpoint/serverless.yml
@@ -10,5 +10,5 @@ functions:
     handler: handler.endpoint
     events:
       - httpApi:
-          path: /ping
+          path: /time
           method: get

--- a/aws-ruby-simple-http-endpoint/README.md
+++ b/aws-ruby-simple-http-endpoint/README.md
@@ -1,6 +1,6 @@
 <!--
 title: .'AWS Simple HTTP Endpoint example in Ruby'
-description: 'This example demonstrates how to setup a simple HTTP GET endpoint. Once you ping it, it will reply with the current time.'
+description: 'This example demonstrates how to setup a simple HTTP GET endpoint. Once you fetch it, it will reply with the current time.'
 framework: v1
 platform: AWS
 language: Ruby
@@ -47,7 +47,7 @@ stack: serverless-ruby-simple-http-endpoint-dev
 api keys:
   None
 endpoints:
-  GET - https://spmfbzc6ja.execute-api.us-east-1.amazonaws.com/ping
+  GET - https://spmfbzc6ja.execute-api.us-east-1.amazonaws.com/time
 functions:
   current_time: serverless-ruby-simple-http-endpoint-dev-current_time
 layers:
@@ -59,7 +59,7 @@ Serverless: Removing old service artifacts from S3...
 Send an HTTP request directly to the endpoint using a tool like curl:
 
 ```bash
-curl https://XXXXXXX.execute-api.us-east-1.amazonaws.com/ping
+curl https://XXXXXXX.execute-api.us-east-1.amazonaws.com/time
 ```
 
 ## Scaling

--- a/aws-ruby-simple-http-endpoint/serverless.yml
+++ b/aws-ruby-simple-http-endpoint/serverless.yml
@@ -10,5 +10,5 @@ functions:
     handler: handler.endpoint
     events:
       - httpApi:
-          path: /ping
+          path: /time
           method: get

--- a/openwhisk-python-simple-http-endpoint/README.md
+++ b/openwhisk-python-simple-http-endpoint/README.md
@@ -26,7 +26,7 @@ Make a note of the API endpoint that is logged to the console during deployment.
 
 ```
 endpoints:
-GET https://xxx.api-gw.mybluemix.net/python-service/ping --> python-service-dev-currentTime
+GET https://xxx.api-gw.mybluemix.net/python-service/time --> python-service-dev-currentTime
 ```
 
 ## 3. Invoke deployed function
@@ -49,14 +49,14 @@ be the API gateway root path, logged during deployment, and your configured
 function path.
 
 ```
-$ http get https://xxx.api-gw.mybluemix.net/python-service/ping
+$ http get https://xxx.api-gw.mybluemix.net/python-service/time
 HTTP/1.1 200 OK
 ...
 {
     "message": "Hello stranger, the current time is 16:00:11.837331"
 }
 
-$ http get https://xxx.api-gw.mybluemix.net/python-service/ping?name=James
+$ http get https://xxx.api-gw.mybluemix.net/python-service/time?name=James
 HTTP/1.1 200 OK
 ...
 {

--- a/openwhisk-python-simple-http-endpoint/serverless.yml
+++ b/openwhisk-python-simple-http-endpoint/serverless.yml
@@ -9,7 +9,7 @@ functions:
     handler: handler.endpoint
     events:
       - http:
-          path: ping
+          path: time
           method: get
 
 plugins:

--- a/openwhisk-swift-simple-http-endpoint/README.md
+++ b/openwhisk-swift-simple-http-endpoint/README.md
@@ -26,11 +26,11 @@ Make a note of the API endpoint that is logged to the console during deployment.
 
 ```
 endpoints:
-GET https://xxx.api-gw.mybluemix.net/swift-service/ping --> swift-service-dev-ping
+GET https://xxx.api-gw.mybluemix.net/swift-service/time --> swift-service-dev-time
 ```
 
 ## 3. Invoke deployed function
-`serverless invoke --function ping` or `serverless invoke -f ping`
+`serverless invoke --function time` or `serverless invoke -f time`
 
 `-f` is shorthand for `--function`
 
@@ -49,14 +49,14 @@ be the API gateway root path, logged during deployment, and your configured
 function path.
 
 ```
-$ http get https://xxx.api-gw.mybluemix.net/swift-service/ping
+$ http get https://xxx.api-gw.mybluemix.net/swift-service/time
 HTTP/1.1 200 OK
 ...
 {
     "message": "Hello stranger, the current time is 16:00:11.837331"
 }
 
-$ http get https://xxx.api-gw.mybluemix.net/swift-service/ping?name=James
+$ http get https://xxx.api-gw.mybluemix.net/swift-service/time?name=James
 HTTP/1.1 200 OK
 ...
 {

--- a/openwhisk-swift-simple-http-endpoint/serverless.yml
+++ b/openwhisk-swift-simple-http-endpoint/serverless.yml
@@ -5,11 +5,11 @@ provider:
   runtime: swift
 
 functions:
-  ping:
-    handler: ping.main
+  time:
+    handler: time.main
     events:
       - http:
-          path: ping
+          path: time
           method: get
 
 


### PR DESCRIPTION
This should ensure that all examples work as intended.
/ping is a default path and provides a healthcheck, for that reason it shouldn't be used.

<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->

Related to #667 