### PR TITLE
Add example for AWS thumbnail tutorial

### DIFF
--- a/aws-node-thumbnail/.gitignore
+++ b/aws-node-thumbnail/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.serverless

--- a/aws-node-thumbnail/README.md
+++ b/aws-node-thumbnail/README.md
@@ -1,0 +1,46 @@
+<!--
+title: 'S3 Image Thumbnailer'
+description: 'This example shows you how to setup a lambda function which, triggered by upload to a source S3 bucket, resizes images to thumbnails and uploads to a thumbnail bucket. '
+layout: Doc
+framework: v1
+platform: AWS
+language: nodeJS
+priority: 10
+authorLink: 'https://github.com/mrjackmclean'
+authorName: 'Jack McLean'
+authorAvatar: 'https://avatars.githubusercontent.com/u/67237620?v=4'
+-->
+
+# Image Thumbnail Creater with Node.js, AWS and Serverless framework
+
+In this example, we set up a lambda function on AWS. When an image is uploaded to the specified S3 bucket, it triggers the lambda function which resizes the image and adds it to the specified thumbnail bucket. The [`sharp` package](https://www.npmjs.com/package/sharp) is used for image resizing.
+
+The serverless example here is loosely adapted from the tutorial [Using an Amazon S3 trigger to create thumbnail images](https://docs.aws.amazon.com/lambda/latest/dg/with-s3-tutorial.html).
+
+## Pre-requisites
+
+In order to deploy the function, you will need the following:
+
+- Serverless framework installed locally via `npm install -g serverless`.
+- API credentials for AWS with Administrator permissions configured in serverless (see [here](https://www.serverless.com/framework/docs/providers/aws/guide/credentials)).
+- Node.js (and npm) installed locally.
+
+## Deploying the Serverless project
+
+1. Clone the repository and install the dependencies (use a wsl terminal - On Windows 10, [install the Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install) to get a Windows-integrated version of Ubuntu and Bash.):\
+
+```
+npm install
+```
+
+2. Open the `handler.js` file and assign globally unique names to the variables `SOURCE_BUCKET_NAME` and `OUTPUT_BUCKET_NAME`.
+
+3. Deploy using serverless (not necessary to use the wsl terminal)
+
+```
+serverless deploy
+```
+
+## Have a suggestion?
+
+Feel free to open an issue on this repository if something doesn’t work or you find an issue. Thanks for reading!

--- a/aws-node-thumbnail/handler.js
+++ b/aws-node-thumbnail/handler.js
@@ -1,0 +1,85 @@
+'use strict';
+
+// dependencies
+// eslint-disable-next-line import/no-extraneous-dependencies
+const AWS = require('aws-sdk');
+const util = require('util');
+const sharp = require('sharp');
+
+const dstBucket = process.env.OUTPUT_BUCKET;
+
+// get reference to S3 client
+const s3 = new AWS.S3();
+
+module.exports.shrinkToThumbnail = async (event) => {
+  // Read options from the event parameter.
+  console.log(
+    'Reading options from event:\n',
+    util.inspect(event, { depth: 5 }),
+  );
+  const srcBucket = event.Records[0].s3.bucket.name;
+  // Object key may have spaces or unicode non-ASCII characters.
+  const srcKey = decodeURIComponent(
+    event.Records[0].s3.object.key.replace(/\+/g, ' '),
+  );
+
+  // Infer the image type from the file suffix.
+  const typeMatch = srcKey.match(/\.([^.]*)$/);
+  if (!typeMatch) {
+    console.log('Could not determine the image type.');
+    return;
+  }
+
+  // Check that the image type is supported
+  const imageType = typeMatch[1].toLowerCase();
+  const extension = typeMatch[0];
+  if (imageType !== 'jpg' && imageType !== 'png') {
+    console.log(`Unsupported image type: ${imageType}`);
+    return;
+  }
+  const dstKey = srcKey.replace(extension, `-thumb${extension}`);
+
+  // Download the image from the S3 source bucket.
+  let origimage;
+  try {
+    const params = {
+      Bucket: srcBucket,
+      Key: srcKey,
+    };
+    origimage = await s3.getObject(params).promise();
+  } catch (error) {
+    console.log(error);
+    return;
+  }
+
+  // set thumbnail width. Resize will set the height automatically to maintain aspect ratio.
+  const width = 200;
+
+  // Use the sharp module to resize the image and save in a buffer.
+  let buffer;
+  try {
+    buffer = await sharp(origimage.Body).resize(width).toBuffer();
+  } catch (error) {
+    console.log(error);
+    return;
+  }
+
+  // Upload the thumbnail image to the destination bucket
+  try {
+    const destparams = {
+      Bucket: dstBucket,
+      Key: dstKey,
+      Body: buffer,
+      ContentType: 'image',
+    };
+
+    await s3.putObject(destparams).promise();
+  } catch (error) {
+    console.log(error);
+    return;
+  }
+
+  console.log(
+    `Successfully resized ${srcBucket}/${srcKey} and uploaded to ${dstBucket}/${dstKey}`,
+  );
+};

--- a/aws-node-thumbnail/package.json
+++ b/aws-node-thumbnail/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sls",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "sharp": "^0.29.3"
+  }
+}

--- a/aws-node-thumbnail/serverless.yml
+++ b/aws-node-thumbnail/serverless.yml
@@ -1,0 +1,47 @@
+service: thumbnailer
+frameworkVersion: "2"
+
+# add custom and globally unique names below
+custom:
+  SOURCE_BUCKET_NAME: 37dd9963-e04f-4393-8ab3-images
+  OUTPUT_BUCKET_NAME: 37dd9963-e04f-4393-8ab3-images-thumb
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  lambdaHashingVersion: 20201221
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - s3:PutObject
+        - s3:PutObjectAcl
+      Resource: "arn:aws:s3:::${self:custom.OUTPUT_BUCKET_NAME}/*"
+    - Effect: Allow
+      Action:
+        - s3:GetObject
+        - s3:GetObjectAcl
+      Resource: "arn:aws:s3:::${self:custom.SOURCE_BUCKET_NAME}/*"
+    - Effect: Allow
+      Action:
+        - logs:PutLogEvents
+        - logs:CreateLogGroup
+        - logs:CreateLogStream
+      Resource:
+        - arn:aws:logs:*:*:*
+
+functions:
+  shrinkToThumbnail:
+    handler: handler.shrinkToThumbnail
+    environment:
+      OUTPUT_BUCKET: ${self:custom.OUTPUT_BUCKET_NAME}
+    events:
+      - s3:
+          bucket: ${self:custom.SOURCE_BUCKET_NAME}
+          event: s3:ObjectCreated:*
+
+resources:
+  Resources:
+    SourceBucketThumb:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: ${self:custom.OUTPUT_BUCKET_NAME}


### PR DESCRIPTION
This is a serverless example for creating a lambda function which, triggered by upload to a source S3 bucket, resizes images to thumbnails and uploads to a thumbnail bucket. The serverless example here is loosely adapted from the tutorial [Using an Amazon S3 trigger to create thumbnail images](https://docs.aws.amazon.com/lambda/latest/dg/with-s3-tutorial.html).