### PR TITLE
feat: Update `.net` examples to .NET 6

### DIFF
--- a/legacy/aws-csharp/Handler.cs
+++ b/legacy/aws-csharp/Handler.cs
@@ -1,31 +1,29 @@
-using Amazon.Lambda.Core;
-
 [assembly:LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
-namespace AwsDotnetCsharp
+
+namespace AwsDotnetCsharp;
+public class Handler
 {
-    public class Handler
+    public Response Hello(Request request)
     {
-       public Response Hello(Request request)
-       {
-           return new Response("Go Serverless v1.0! Your function executed successfully!", request);
-       }
+        return new Response("Go Serverless v1.0! Your function executed successfully!", request);
     }
+}
 
-    public class Response
-    {
-      public string Message {get; set;}
-      public Request Request {get; set;}
+public class Response
+{
+  public string Message {get; set;}
+  public Request Request {get; set;}
 
-      public Response(string message, Request request){
-        Message = message;
-        Request = request;
-      }
-    }
+  public Response(string message, Request request)
+  {
+    Message = message;
+    Request = request;
+  }
+}
 
-    public class Request
-    {
-      public string Key1 {get; set;}
-      public string Key2 {get; set;}
-      public string Key3 {get; set;}
-    }
+public class Request
+{
+  public string Key1 {get; set;}
+  public string Key2 {get; set;}
+  public string Key3 {get; set;}
 }

--- a/legacy/aws-csharp/aws-csharp.csproj
+++ b/legacy/aws-csharp/aws-csharp.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>CsharpHandlers</AssemblyName>
     <PackageId>aws-csharp</PackageId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/legacy/aws-csharp/aws-csharp.csproj
+++ b/legacy/aws-csharp/aws-csharp.csproj
@@ -5,11 +5,16 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>CsharpHandlers</AssemblyName>
     <PackageId>aws-csharp</PackageId>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Amazon.Lambda.Core" />
   </ItemGroup>
 
 </Project>

--- a/legacy/aws-csharp/aws-csharp.csproj
+++ b/legacy/aws-csharp/aws-csharp.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>CsharpHandlers</AssemblyName>
     <PackageId>aws-csharp</PackageId>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <PublishReadyToRun>true</PublishReadyToRun>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/legacy/aws-csharp/build.cmd
+++ b/legacy/aws-csharp/build.cmd
@@ -1,3 +1,3 @@
 dotnet restore
-dotnet tool install -g Amazon.Lambda.Tools --framework netcoreapp3.1
-dotnet lambda package --configuration Release --framework netcoreapp3.1 --output-package bin/Release/netcoreapp3.1/hello.zip
+dotnet tool install -g Amazon.Lambda.Tools --framework net6.0
+dotnet lambda package --configuration Release --framework net6.0 --output-package bin/Release/net6.0/hello.zip

--- a/legacy/aws-csharp/build.sh
+++ b/legacy/aws-csharp/build.sh
@@ -8,5 +8,5 @@ then
 fi
 
 dotnet restore
-dotnet tool install -g Amazon.Lambda.Tools --framework netcoreapp3.1
-dotnet lambda package --configuration Release --framework netcoreapp3.1 --output-package bin/Release/netcoreapp3.1/hello.zip
+dotnet tool install -g Amazon.Lambda.Tools --framework net6.0
+dotnet lambda package --configuration Release --framework net6.0 --output-package bin/Release/net6.0/hello.zip

--- a/legacy/aws-csharp/serverless.yml
+++ b/legacy/aws-csharp/serverless.yml
@@ -22,7 +22,7 @@ frameworkVersion: '3'
 
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet6
 
 # you can overwrite defaults here
 #  stage: dev
@@ -59,7 +59,7 @@ functions:
 
     # you can add packaging information here
     package:
-      artifact: bin/Release/netcoreapp3.1/hello.zip
+      artifact: bin/Release/net6.0/hello.zip
     #  exclude:
     #    - exclude-me.js
     #    - exclude-me-dir/**

--- a/legacy/aws-fsharp/aws-fsharp.fsproj
+++ b/legacy/aws-fsharp/aws-fsharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>FsharpHandlers</AssemblyName>
     <PackageId>aws-fsharp</PackageId>
   </PropertyGroup>
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.0.1" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/legacy/aws-fsharp/aws-fsharp.fsproj
+++ b/legacy/aws-fsharp/aws-fsharp.fsproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>FsharpHandlers</AssemblyName>
     <PackageId>aws-fsharp</PackageId>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>

--- a/legacy/aws-fsharp/build.cmd
+++ b/legacy/aws-fsharp/build.cmd
@@ -1,4 +1,4 @@
 dotnet restore
-dotnet tool install -g Amazon.Lambda.Tools --framework netcoreapp3.1
+dotnet tool install -g Amazon.Lambda.Tools --framework net6.0
 
-dotnet lambda package --configuration Release --framework netcoreapp3.1 --output-package bin/Release/netcoreapp3.1/deploy-package.zip
+dotnet lambda package --configuration Release --framework net6.0 --output-package bin/Release/net6.0/deploy-package.zip

--- a/legacy/aws-fsharp/build.sh
+++ b/legacy/aws-fsharp/build.sh
@@ -8,5 +8,5 @@ then
 fi
 
 dotnet restore
-dotnet tool install -g Amazon.Lambda.Tools --framework netcoreapp3.1
-dotnet lambda package --configuration Release --framework netcoreapp3.1 --output-package bin/Release/netcoreapp3.1/deploy-package.zip
+dotnet tool install -g Amazon.Lambda.Tools --framework net6.0
+dotnet lambda package --configuration Release --framework net6.0 --output-package bin/Release/net6.0/deploy-package.zip

--- a/legacy/aws-fsharp/serverless.yml
+++ b/legacy/aws-fsharp/serverless.yml
@@ -22,7 +22,7 @@ frameworkVersion: '3'
 
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet6
 
 # you can overwrite defaults here
 #  stage: dev
@@ -52,7 +52,7 @@ provider:
 
 # you can add packaging information here
 package:
-  artifact: bin/Release/netcoreapp3.1/deploy-package.zip
+  artifact: bin/Release/net6.0/deploy-package.zip
 #  exclude:
 #    - exclude-me.js
 #    - exclude-me-dir/**


### PR DESCRIPTION
Updates the C# and F# AWS Lambda legacy templates to use the .NET 6 managed Lambda runtime.