### PR TITLE
Create a basic TypeScript example

### DIFF
--- a/aws-node-typescript/.gitignore
+++ b/aws-node-typescript/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+.esbuild
+
+# Serverless directories
+.serverless

--- a/aws-node-typescript/README.md
+++ b/aws-node-typescript/README.md
@@ -1,0 +1,72 @@
+<!--
+title: 'AWS TypeScript Example'
+description: 'This template demonstrates how to deploy a TypeScript function running on AWS Lambda using Serverless Framework.'
+layout: Doc
+framework: v3
+platform: AWS
+language: nodeJS
+priority: 1
+authorLink: 'https://github.com/serverless'
+authorName: 'Serverless, inc.'
+authorAvatar: 'https://avatars1.githubusercontent.com/u/13742415?s=200&v=4'
+-->
+
+
+# Serverless Framework AWS TypeScript Example
+
+This template demonstrates how to deploy a TypeScript function running on AWS Lambda using Serverless Framework. The deployed function does not include any event definitions as well as any kind of persistence (database). For more advanced configurations check out the [examples repo](https://github.com/serverless/examples/) which includes integrations with SQS, DynamoDB or examples of functions that are triggered in `cron`-like manner. For details about configuration of specific `events`, please refer to our [documentation](https://www.serverless.com/framework/docs/providers/aws/events/).
+
+## Usage
+
+### Deployment
+
+In order to deploy the example, you need to run the following command:
+
+```
+$ serverless deploy
+```
+
+After running deploy, you should see output similar to:
+
+```bash
+Deploying aws-node-typescript to stage dev (us-east-1)
+
+✔ Service deployed to stack aws-node-typescript-dev (112s)
+
+functions:
+  hello: aws-node-typescript-dev-hello (806 B)
+```
+
+### Invocation
+
+After successful deployment, you can invoke the deployed function by using the following command:
+
+```bash
+serverless invoke --function hello
+```
+
+Which should result in response similar to the following:
+
+```json
+{
+    "message": "Go Serverless v3! Your function executed successfully!",
+    "input": {}
+}
+```
+
+### Local development
+
+You can invoke your function locally by using the following command:
+
+```bash
+serverless invoke local --function hello
+```
+
+Which should result in response similar to the following:
+
+```
+{
+    "message": "Go Serverless v3! Your function executed successfully!",
+    "input": {}
+}
+```

--- a/aws-node-typescript/handler.ts
+++ b/aws-node-typescript/handler.ts
@@ -1,0 +1,6 @@
+export async function hello(event) {
+  return {
+    message: 'Go Serverless v3! Your function executed successfully!',
+    input: event,
+  };
+}

--- a/aws-node-typescript/package.json
+++ b/aws-node-typescript/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "esbuild": "^0.14.25",
+    "serverless-esbuild": "^1.25.0"
+  }
+}

--- a/aws-node-typescript/serverless.yml
+++ b/aws-node-typescript/serverless.yml
@@ -1,0 +1,13 @@
+service: aws-node-typescript # NOTE: update this with your service name
+frameworkVersion: '3'
+
+provider:
+  name: aws
+  runtime: nodejs14.x
+
+functions:
+  hello:
+    handler: handler.hello
+
+plugins:
+  - serverless-esbuild

--- a/examples.json
+++ b/examples.json
@@ -436,6 +436,19 @@
     "authorAvatar": "https://avatars2.githubusercontent.com/u/8251208?v=4&s=140"
   },
   {
+    "title": "AWS TypeScript example",
+    "name": "aws-node-typescript",
+    "description": "This template demonstrates how to deploy a TypeScript function running on AWS Lambda using the traditional Serverless Framework.",
+    "githubUrl": "https://github.com/serverless/examples/tree/master/aws-node-typescript",
+    "framework": "v2",
+    "language": "node",
+    "platform": "aws",
+    "authorLink": "https://github.com/serverless",
+    "authorName": "Serverless, inc.",
+    "authorAvatar": "https://avatars1.githubusercontent.com/u/13742415?s=200&v=4",
+    "priority": 1
+  },
+  {
     "title": "AWS Simple HTTP Endpoint example in NodeJS with Typescript",
     "name": "aws-node-rest-api-typescript-simple",
     "description": "This template demonstrates how to make a simple REST API with Node.js and Typescript running on AWS Lambda and API Gateway using the Serverless Framework v1.",


### PR DESCRIPTION
This follows the discussion in https://github.com/serverless/examples/pull/681#issuecomment-1052007939

This is a basic TypeScript example based on the basic Node (JS) example. It uses the `esbuild` plugin as discussed in https://github.com/serverless/serverless/issues/10700