### PR TITLE
fix: GraphQL query endpoint errors

### DIFF
--- a/aws-node-graphql-api-with-dynamodb/README.md
+++ b/aws-node-graphql-api-with-dynamodb/README.md
@@ -57,7 +57,11 @@ const schema = new GraphQLSchema({
 
 // We want to make a GET request with ?query=<graphql query>
 // The event properties are specific to AWS. Other providers will differ.
-module.exports.query = (event, context, callback) => graphql(schema, event.queryStringParameters.query)
+module.exports.query = (event, context, callback) =>
+  graphql({
+    schema,
+    source: event.queryStringParameters.query
+  })
   .then(
     result => callback(null, {statusCode: 200, body: JSON.stringify(result)}),
     err => callback(err)

--- a/aws-node-graphql-api-with-dynamodb/handler.js
+++ b/aws-node-graphql-api-with-dynamodb/handler.js
@@ -77,7 +77,10 @@ const schema = new GraphQLSchema({
 // We want to make a GET request with ?query=<graphql query>
 // The event properties are specific to AWS. Other providers will differ.
 module.exports.query = (event, context, callback) =>
-  graphql(schema, event.queryStringParameters.query)
+  graphql({
+    schema,
+    source: event.queryStringParameters.query
+  })
   .then(
     result => callback(null, { statusCode: 200, body: JSON.stringify(result) }),
     err => callback(err)


### PR DESCRIPTION
graphql function params are passed incorrectly in example

https://stackoverflow.com/questions/70567470/error-expected-undefined-to-be-a-graphql-schema-on-hello-world
