### PR TITLE
Update requirements.txt

### DIFF
--- a/aws-python-flask-dynamodb-api/requirements.txt
+++ b/aws-python-flask-dynamodb-api/requirements.txt
@@ -1,3 +1,3 @@
 Flask==1.1.4
 Werkzeug==1.0.1
-
+markupsafe==2.0.1


### PR DESCRIPTION
Same issue as in Flask API example: Current V3 version is not functioning due to change of Markupsafe module in WSGI. Execution of Lambda function exits with
"errorMessage": "Unable to import app.app"
Proposed fix: pin the older version of markupsafe in requirements.txt by adding:

<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

Make sure to lint your code to match the rest of the repo.

Run `npm run lint` to lint

-->