### PR TITLE
feat: Update `aws-python-telegram-bot` to v3 and using httpApi

### DIFF
--- a/aws-python-telegram-bot/handler.py
+++ b/aws-python-telegram-bot/handler.py
@@ -45,7 +45,7 @@ def webhook(event, context):
     bot = configure_telegram()
     logger.info('Event: {}'.format(event))
 
-    if event.get('httpMethod') == 'POST' and event.get('body'): 
+    if event.get('requestContext', {}).get('http', {}).get('method') == 'POST' and event.get('body'): 
         logger.info('Message received')
         update = telegram.Update.de_json(json.loads(event.get('body')), bot)
         chat_id = update.message.chat.id
@@ -72,7 +72,7 @@ def set_webhook(event, context):
     logger.info('Event: {}'.format(event))
     bot = configure_telegram()
     url = 'https://{}/{}/'.format(
-        event.get('headers').get('Host'),
+        event.get('headers').get('host'),
         event.get('requestContext').get('stage'),
     )
     webhook = bot.set_webhook(url)

--- a/aws-python-telegram-bot/package.json
+++ b/aws-python-telegram-bot/package.json
@@ -15,7 +15,7 @@
   "author": "jonatasbaldin",
   "license": "MIT",
   "dependencies": {
-    "serverless-python-requirements": "^3.0.9"
+    "serverless-python-requirements": "^5.4.0"
   },
   "bugs": {
     "url": "https://github.com/jonatasbaldin/serverless-telegram-bot/issues"

--- a/aws-python-telegram-bot/requirements.txt
+++ b/aws-python-telegram-bot/requirements.txt
@@ -1,1 +1,1 @@
-python-telegram-bot==8.1.1
+python-telegram-bot==13.11

--- a/aws-python-telegram-bot/serverless.yml
+++ b/aws-python-telegram-bot/serverless.yml
@@ -11,12 +11,16 @@ functions:
   webhook:
     handler: handler.webhook
     events:
-      - http: POST /
+      - httpApi:
+          path: /
+          method: POST
 
   set_webhook:
     handler: handler.set_webhook
     events:
-      - http: POST /set_webhook
+      - httpApi:
+          path: /set_webhook
+          method: POST
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
Current example `aws-python-telegram-bot` does not work with old version of serverless-python-requirements
so upgrade to latest version .

When changed from API gateway v1 to v2 httpApi, some fields in the  are changed.
