### PR TITLE
fix golang http-get-post sample

### DIFF
--- a/aws-golang-http-get-post/serverless.yml
+++ b/aws-golang-http-get-post/serverless.yml
@@ -85,7 +85,7 @@ functions:
     handler: bin/postBin
     package:
       include:
-        - ./bin/getQueryBin
+        - ./bin/postBin
     events:
       - http:
           path: post


### PR DESCRIPTION
Golang http-get-post sample contained invalid servlerless.yml configuration which caused lambda function to fail due to missing handler binary.