### PR TITLE
feat: Update python to 3.9 in `aws-python-http-api` example

### DIFF
--- a/aws-python-http-api/serverless.yml
+++ b/aws-python-http-api/serverless.yml
@@ -3,7 +3,7 @@ frameworkVersion: '3'
 
 provider:
   name: aws
-  runtime: python3.8
+  runtime: python3.9
 
 functions:
   hello:


### PR DESCRIPTION
As in title