### PR TITLE
Add example to community-examples.json

### DIFF
--- a/community-examples.json
+++ b/community-examples.json
@@ -632,5 +632,10 @@
     "name": "Serverless Typescript cognito local lambda triggers",
     "description": "Serverless Framework example to run a cognito triggered lambda locally using Serverless offline",
     "githubUrl": "https://github.com/nanlabs/devops-reference/tree/main/examples/serverless-cognito-local"
+  },
+  {
+    "name": "Serverless SQS offline + TypeScript + ElasticMQ Example",
+    "description": "Serverless Framework example to run AWS SQS service locally using https://github.com/softwaremill/elasticmq",
+    "githubUrl": "https://github.com/nanlabs/devops-reference/tree/main/examples/serverless-sqs-node-typescript-offline-with-elasticmq"
   }
 ]


### PR DESCRIPTION
Added the following community example:

[AWS SQS + TypeScript + ElasticMQ](https://github.com/nanlabs/devops-reference/tree/main/examples/serverless-sqs-node-typescript-offline-with-elasticmq/) - Serverless Framework example to run AWS SQS service locally environment using [Serverless Offline](https://www.serverless.com/plugins/serverless-offline) and [ElasticMQ](https://github.com/softwaremill/elasticmq).

This example comes from [NaNLABS' DevOps Reference](https://github.com/nanlabs/devops-reference). 