### PR TITLE
feat: add sqs offline with python and localstack example

### DIFF
--- a/community-examples.json
+++ b/community-examples.json
@@ -637,5 +637,10 @@
     "name": "Serverless SQS offline + TypeScript + ElasticMQ Example",
     "description": "Serverless Framework example to run AWS SQS service locally using https://github.com/softwaremill/elasticmq",
     "githubUrl": "https://github.com/nanlabs/devops-reference/tree/main/examples/serverless-sqs-node-typescript-offline-with-elasticmq"
+  },
+  {
+    "name": "Serverless SQS offline + Python + Localstack",
+    "description": "Serverless Framework example to run AWS SQS service locally using https://github.com/localstack",
+    "githubUrl": "https://github.com/nanlabs/devops-reference/tree/main/examples/serverless-sqs-python"
   }
 ]


### PR DESCRIPTION
Add [AWS SQS + Python + Localstack](https://github.com/nanlabs/devops-reference/tree/main/examples/serverless-sqs-python) - Serverless Framework example to run AWS SQS service locally environment using [Serverless Offline](https://www.serverless.com/plugins/serverless-offline) and [Localstack](https://github.com/localstack).

This example comes from [NaNLABS' DevOps Reference](https://github.com/nanlabs/devops-reference).