### PR TITLE
revert update for tslint

### DIFF
--- a/aws-node-rest-api-typescript/package.json
+++ b/aws-node-rest-api-typescript/package.json
@@ -36,7 +36,7 @@
     "serverless-plugin-typescript": "^1.1.9",
     "sinon": "^9.0.2",
     "ts-node": "^8.9.1",
-    "tslint": "^6.1.2",
+    "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.11.2",
     "typescript": "^3.8.3"
   },


### PR DESCRIPTION
stop npm install from failing for 
`serverless --template-url=https://github.com/serverless/examples/tree/v3/aws-node-rest-api-typescript`

this resolves version conflicts between version of TSLint that is required by the root project and the version required by the "tslint-config-airbnb" package.


this issue may be present on other examples too so pls check and resolve as required. 




<!-- Hi there ⊂◉‿◉つ

Thanks for submitting a PR! We're excited to see what you've got for us!

-->