### PR TITLE
fix: aws-node-single-page-app-via-cloudfront config

### DIFF
--- a/aws-node-single-page-app-via-cloudfront/serverless.yml
+++ b/aws-node-single-page-app-via-cloudfront/serverless.yml
@@ -6,7 +6,7 @@ plugins:
   - serverless-single-page-app-plugin
 
 custom:
-  s3Bucket: yourBucketName123
+  s3Bucket: your-bucket-name123
 
 provider:
   name: aws
@@ -19,7 +19,11 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: ${self:custom.s3Bucket}
-        AccessControl: PublicRead
+        OwnershipControls:
+          Rules:
+            - ObjectOwnership: ObjectWriter
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: false
         WebsiteConfiguration:
           IndexDocument: index.html
           ErrorDocument: index.html


### PR DESCRIPTION
Related to: https://aws.amazon.com/blogs/aws/amazon-s3-block-public-access-another-layer-of-protection-for-your-accounts-and-buckets/

Fixes:-
- error `Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting`
- error `An error occurred: WebAppS3BucketPolicy - API: s3:PutBucketPolicy Access Denied.`
- error `Bucket name should not contain uppercase character`