### PR TITLE
fix:#757 change serverless function from hello to api

### DIFF
--- a/aws-node-http-api/README.md
+++ b/aws-node-http-api/README.md
@@ -62,7 +62,7 @@ Which should result in response similar to the following (removed `input` conten
 You can invoke your function locally by using the following command:
 
 ```bash
-serverless invoke local --function hello
+serverless invoke local --function api
 ```
 
 Which should result in response similar to the following:


### PR DESCRIPTION
fixes: #757 
change serveless function from `hello` to `api`

before:
```bash
serverless invoke local --function hello
```

After:
```bash
serverless invoke local --function api
```