### PR TITLE
fix: updated esbuild and serverless-esbuild

### DIFF
--- a/aws-node-typescript/package.json
+++ b/aws-node-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "esbuild": "^0.14.25",
-    "serverless-esbuild": "^1.25.0"
+    "esbuild": "^0.19.3",
+    "serverless-esbuild": "^1.48.3"
   }
 }


### PR DESCRIPTION
once ```npm install``` and ```serverless deploy``` are executed, the following error shows:

```
Error:
TypeError: pkg?.context is not a function
```