### PR TITLE
fix: aws-node-express-dynamodb-api return early in case of validation error

### DIFF
--- a/aws-node-express-dynamodb-api/index.js
+++ b/aws-node-express-dynamodb-api/index.js
@@ -43,9 +43,9 @@ app.get("/users/:userId", async function (req, res) {
 app.post("/users", async function (req, res) {
   const { userId, name } = req.body;
   if (typeof userId !== "string") {
-    res.status(400).json({ error: '"userId" must be a string' });
+    return res.status(400).json({ error: '"userId" must be a string' });
   } else if (typeof name !== "string") {
-    res.status(400).json({ error: '"name" must be a string' });
+    return res.status(400).json({ error: '"name" must be a string' });
   }
 
   const params = {


### PR DESCRIPTION
In the aws-node-express-dynamodb-api example, it currently returns a 500 error in the case of a validation error, when it should be returning a 400 Bad Request. This PR aims to address this issue by implementing an early return.

![Image](https://github.com/serverless/examples/assets/29201861/ff5298d7-ff27-4074-bad2-c16849a4fdac)
