### PR TITLE
refactor: remove deprecated `sinatra-contrib` gem

### DIFF
--- a/aws-ruby-sinatra-dynamodb-api/Gemfile
+++ b/aws-ruby-sinatra-dynamodb-api/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'sinatra'
-gem 'sinatra-contrib'
 gem 'aws-sdk-dynamodb'


### PR DESCRIPTION
This PR removes deprecated `sinatra-contrib` gem from `aws-ruby-sinatra-dynamodb-api` example