### PR TITLE
chore: remove aws-lambda dependency

### DIFF
--- a/aws-node-typescript-kinesis/package.json
+++ b/aws-node-typescript-kinesis/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "serverless-webpack": "^5.2.0",
-    "aws-lambda": "^1.0.5",
     "aws-sdk": "^2.553.0",
     "source-map-support": "^0.5.10",
     "uuid": "^8.2.0"

--- a/aws-node-typescript-sqs-standard/package.json
+++ b/aws-node-typescript-sqs-standard/package.json
@@ -8,7 +8,6 @@
     "lint": "tslint -p tsconfig.json -c tslint.json"
   },
   "dependencies": {
-    "aws-lambda": "^0.1.2",
     "aws-sdk": "^2.553.0",
     "source-map-support": "^0.5.10"
   },


### PR DESCRIPTION
The `aws-lambda` package is actually a CLI, unrelated to imports of the `"aws-lambda"` path.

At run-time, AWS will make the `aws-lambda` module available (meaning it doesn't need to be installed as an NPM dependency, and can't be).

The `@types/aws-lambda` package does however provide types for the actual aws-lambda module.
