### PR TITLE
Fix #793 fix outdated nodejs MongoDB Atlas example

### DIFF
--- a/aws-node-mongodb-atlas/handler.js
+++ b/aws-node-mongodb-atlas/handler.js
@@ -10,8 +10,9 @@ const mongoClusterName = '';
 const mongoUser = '';
 const mongoDbName = '';
 const mongoPass = '';
+const clusterName = "";
 
-const mongoConnStr = `mongodb+srv://${mongoUser}:${mongoPass}@${mongoClusterName}-tdoka.mongodb.net/${mongoDbName}?retryWrites=true`;
+const mongoConnStr = `mongodb+srv://${mongoUser}:${mongoPass}@${mongoClusterName}/${mongoDbName}?retryWrites=true&w=majority&appName=${clusterName}`;
 
 const getPetType = () => {
     const msNow = Date.now();
@@ -52,17 +53,17 @@ const performQuery = async () => {
 const app = express();
 
 app.get('/hello', async function (req, res) {
-    if (!client.isConnected()) {
+    // if (!client.isConnected()) { // no longer existing for newer mongodb lib versions
         // Cold start or connection timed out. Create new connection.
         try {
-            await createConn();
+            await createConn();  // no-op if already connected
         } catch (e) {
             res.json({
                 error: e.message,
             });
             return;
         }
-    }
+    // }
 
     // Connection ready. Perform insert and return result.
     try {

--- a/aws-node-mongodb-atlas/package.json
+++ b/aws-node-mongodb-atlas/package.json
@@ -12,7 +12,7 @@
     "dependencies": {
       "express": "^4.16.4",
       "faker": "^4.1.0",
-      "mongodb": "^3.1.13",
+      "mongodb": "^6.8.0",
       "serverless-http": "^1.9.0"
     }
   }

--- a/aws-node-mongodb-atlas/serverless.yml
+++ b/aws-node-mongodb-atlas/serverless.yml
@@ -2,7 +2,7 @@ service: my-service # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs20.x
 
 functions:
   hello:


### PR DESCRIPTION
Fixes #793 
- nodejs 14 version in serverless.yml no longer supported at AWS
- used mongodb lib version caused connection error with current MongoDB Atlas
- connection string didn't work with current MongoDB Atlas
- isConnected() no longer supported for current mongodb lib version