### PR TITLE
Configure package minimum release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+npmMinimalAgeGate: "3d"


### PR DESCRIPTION
## Summary
- Configure package manager installs to reject newly published packages until they are at least 3 days old.
- Update `.npmrc` with the package-age gate.
- Update `.yarnrc.yml` with the package-age gate.
- Note: Yarn lockfile v1 detected in examples; this adds the modern Yarn age-gate config alongside npm config.
## Testing
- Not run; configuration-only change.