### PR TITLE
fix: quote frontmatter values containing colons

### DIFF
--- a/aws-bedrock-agentcore/javascript/langgraph-basic-dockerfile/README.md
+++ b/aws-bedrock-agentcore/javascript/langgraph-basic-dockerfile/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Basic Agent, Dockerfile Deploy (JavaScript)
+title: 'Bedrock AgentCore: LangGraph Basic Agent, Dockerfile Deploy (JavaScript)'
 description: Minimal LangGraph JS agent deployed to AWS Bedrock AgentCore via a custom Dockerfile build.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/javascript/langgraph-basic/README.md
+++ b/aws-bedrock-agentcore/javascript/langgraph-basic/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Basic Agent, Code Deploy (JavaScript)
+title: 'Bedrock AgentCore: LangGraph Basic Agent, Code Deploy (JavaScript)'
 description: Minimal LangGraph JS agent built automatically from source with no Dockerfile, deployed to AWS Bedrock AgentCore.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/javascript/langgraph-browser-custom/README.md
+++ b/aws-bedrock-agentcore/javascript/langgraph-browser-custom/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Custom Browser (JavaScript)
+title: 'Bedrock AgentCore: LangGraph Agent with Custom Browser (JavaScript)'
 description: LangGraph JS agent using a custom AgentCore Browser resource with session recording to S3.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/javascript/langgraph-browser/README.md
+++ b/aws-bedrock-agentcore/javascript/langgraph-browser/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Managed Browser (JavaScript)
+title: 'Bedrock AgentCore: LangGraph Agent with Managed Browser (JavaScript)'
 description: LangGraph JS agent using the AWS-managed AgentCore Browser tool for web navigation and screenshots.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/javascript/langgraph-code-interpreter-custom/README.md
+++ b/aws-bedrock-agentcore/javascript/langgraph-code-interpreter-custom/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Custom Code Interpreter (JavaScript)
+title: 'Bedrock AgentCore: LangGraph Agent with Custom Code Interpreter (JavaScript)'
 description: LangGraph JS agent using a custom AgentCore Code Interpreter with PUBLIC network access.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/javascript/langgraph-code-interpreter/README.md
+++ b/aws-bedrock-agentcore/javascript/langgraph-code-interpreter/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Managed Code Interpreter (JavaScript)
+title: 'Bedrock AgentCore: LangGraph Agent with Managed Code Interpreter (JavaScript)'
 description: LangGraph JS agent using the AWS-managed AgentCore Code Interpreter for sandboxed code execution.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/javascript/langgraph-comprehensive/README.md
+++ b/aws-bedrock-agentcore/javascript/langgraph-comprehensive/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Comprehensive Agent (JavaScript)
+title: 'Bedrock AgentCore: LangGraph Comprehensive Agent (JavaScript)'
 description: LangGraph JS agent combining Gateway tools, a direct MCP connection, browser, code interpreter, and memory in one deployment.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/javascript/langgraph-gateway/README.md
+++ b/aws-bedrock-agentcore/javascript/langgraph-gateway/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Gateway Tools (JavaScript)
+title: 'Bedrock AgentCore: LangGraph Agent with Gateway Tools (JavaScript)'
 description: LangGraph JS agent exposing Lambda-backed tools through an AgentCore Gateway over MCP.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/javascript/langgraph-memory/README.md
+++ b/aws-bedrock-agentcore/javascript/langgraph-memory/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Memory (JavaScript)
+title: 'Bedrock AgentCore: LangGraph Agent with Memory (JavaScript)'
 description: LangGraph JS agent using AgentCore Memory to persist and recall conversation history.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/javascript/langgraph-multi-gateway/README.md
+++ b/aws-bedrock-agentcore/javascript/langgraph-multi-gateway/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Multi-Gateway Agents (JavaScript)
+title: 'Bedrock AgentCore: LangGraph Multi-Gateway Agents (JavaScript)'
 description: LangGraph JS agents using separate public and private AgentCore Gateways with different authorization levels.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/javascript/langgraph-streaming/README.md
+++ b/aws-bedrock-agentcore/javascript/langgraph-streaming/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Token Streaming (JavaScript)
+title: 'Bedrock AgentCore: LangGraph Agent with Token Streaming (JavaScript)'
 description: LangGraph JS agent streaming LLM tokens in real time over SSE via BedrockAgentCoreApp.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/javascript/mcp-server/README.md
+++ b/aws-bedrock-agentcore/javascript/mcp-server/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: Standalone MCP Server (JavaScript)
+title: 'Bedrock AgentCore: Standalone MCP Server (JavaScript)'
 description: Standalone JavaScript MCP server deployed to AWS Bedrock AgentCore Runtime, consumable by any MCP client.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/javascript/strands-browser/README.md
+++ b/aws-bedrock-agentcore/javascript/strands-browser/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: Strands Agent with Browser (JavaScript)
+title: 'Bedrock AgentCore: Strands Agent with Browser (JavaScript)'
 description: Strands Agents JavaScript agent using AgentCore Browser tools for web automation.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/python/langgraph-basic-code/README.md
+++ b/aws-bedrock-agentcore/python/langgraph-basic-code/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Basic Agent, Code Deploy (Python)
+title: 'Bedrock AgentCore: LangGraph Basic Agent, Code Deploy (Python)'
 description: Minimal LangGraph agent deployed to AWS Bedrock AgentCore using code (zip) deployment.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/python/langgraph-basic-docker/README.md
+++ b/aws-bedrock-agentcore/python/langgraph-basic-docker/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Basic Agent, Docker Deploy (Python)
+title: 'Bedrock AgentCore: LangGraph Basic Agent, Docker Deploy (Python)'
 description: Minimal LangGraph agent deployed to AWS Bedrock AgentCore using Docker/container deployment.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/python/langgraph-browser-custom/README.md
+++ b/aws-bedrock-agentcore/python/langgraph-browser-custom/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Custom Browser (Python)
+title: 'Bedrock AgentCore: LangGraph Agent with Custom Browser (Python)'
 description: LangGraph agent using a custom AgentCore Browser resource with session recording to S3.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/python/langgraph-browser/README.md
+++ b/aws-bedrock-agentcore/python/langgraph-browser/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Managed Browser (Python)
+title: 'Bedrock AgentCore: LangGraph Agent with Managed Browser (Python)'
 description: LangGraph agent using AgentCore Browser via LangChain's browser toolkit for web automation.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/python/langgraph-code-interpreter-custom/README.md
+++ b/aws-bedrock-agentcore/python/langgraph-code-interpreter-custom/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Custom Code Interpreter (Python)
+title: 'Bedrock AgentCore: LangGraph Agent with Custom Code Interpreter (Python)'
 description: LangGraph agent using a custom AgentCore Code Interpreter with PUBLIC network mode.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/python/langgraph-code-interpreter/README.md
+++ b/aws-bedrock-agentcore/python/langgraph-code-interpreter/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Managed Code Interpreter (Python)
+title: 'Bedrock AgentCore: LangGraph Agent with Managed Code Interpreter (Python)'
 description: LangGraph agent using the AWS-managed AgentCore Code Interpreter (SANDBOX mode) for Python execution.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/python/langgraph-gateway/README.md
+++ b/aws-bedrock-agentcore/python/langgraph-gateway/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Gateway Tools (Python)
+title: 'Bedrock AgentCore: LangGraph Agent with Gateway Tools (Python)'
 description: LangGraph agent exposing custom Lambda function tools via an auto-created AgentCore Gateway.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/python/langgraph-memory/README.md
+++ b/aws-bedrock-agentcore/python/langgraph-memory/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Agent with Memory (Python)
+title: 'Bedrock AgentCore: LangGraph Agent with Memory (Python)'
 description: LangGraph agent using AgentCore Memory as a tool for recalling and saving conversation history.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/python/langgraph-multi-gateway/README.md
+++ b/aws-bedrock-agentcore/python/langgraph-multi-gateway/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: LangGraph Multi-Gateway Agents (Python)
+title: 'Bedrock AgentCore: LangGraph Multi-Gateway Agents (Python)'
 description: LangGraph agent using multiple AgentCore Gateways with different authorization types and tool subsets.
 layout: Doc
 framework: v4

--- a/aws-bedrock-agentcore/python/strands-browser/README.md
+++ b/aws-bedrock-agentcore/python/strands-browser/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Bedrock AgentCore: Strands Agent with Browser (Python)
+title: 'Bedrock AgentCore: Strands Agent with Browser (Python)'
 description: Strands Agents agent using AgentCore Browser for web automation and research tasks.
 layout: Doc
 framework: v4

--- a/sandboxes/complete/README.md
+++ b/sandboxes/complete/README.md
@@ -1,6 +1,6 @@
 <!--
-title: Serverless Framework Sandboxes: Complete AWS Lambda MicroVM Example
-description: Deploy-as-is showcase of every sandboxes property: Dockerfile build, memory, hooks, observability, IAM, and tags.
+title: 'Serverless Framework Sandboxes: Complete AWS Lambda MicroVM Example'
+description: 'Deploy-as-is showcase of every sandboxes property: Dockerfile build, memory, hooks, observability, IAM, and tags.'
 layout: Doc
 framework: v4
 platform: AWS

--- a/sandboxes/minimal/README.md
+++ b/sandboxes/minimal/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Serverless Framework Sandboxes: Minimal AWS Lambda MicroVM Example
+title: 'Serverless Framework Sandboxes: Minimal AWS Lambda MicroVM Example'
 description: Smallest possible sandboxes configuration, using only the required artifact field and framework defaults.
 layout: Doc
 framework: v4

--- a/sandboxes/self-hosted-webhook/README.md
+++ b/sandboxes/self-hosted-webhook/README.md
@@ -1,5 +1,5 @@
 <!--
-title: Serverless Framework Sandboxes: Self-Hosted Webhook for Claude Managed Agents
+title: 'Serverless Framework Sandboxes: Self-Hosted Webhook for Claude Managed Agents'
 description: Self-hosted AWS Lambda MicroVM sandbox per Claude Managed Agent session, launched on demand by a webhook.
 layout: Doc
 framework: v4

--- a/validate.js
+++ b/validate.js
@@ -43,6 +43,13 @@ for (const dir of findExampleDirs(ROOT)) {
   for (const key of REQUIRED) if (!fm[key]) errors.push(`${rel}: frontmatter missing "${key}"`);
   if (fm.title === 'TODO') errors.push(`${rel}: frontmatter title is TODO`);
   if (fm.framework && fm.framework !== 'v4') errors.push(`${rel}: frontmatter framework is "${fm.framework}", expected "v4"`);
+  // serverless.com converts the frontmatter comment to YAML; an unquoted value
+  // containing ": " is invalid YAML there and blanks the example's page.
+  for (const [key, value] of Object.entries(fm)) {
+    if (value.includes(': ') && !/^['"]/.test(value)) {
+      errors.push(`${rel}: frontmatter "${key}" contains ": " — quote the value (breaks YAML parsing on serverless.com)`);
+    }
+  }
 }
 
 if (errors.length) {


### PR DESCRIPTION
All 26 bedrock-agentcore and sandboxes example pages rendered blank on serverless.com/examples.

**Cause:** the website renders each README's frontmatter block as YAML. `title: Bedrock AgentCore: Strands Agent with Browser (Python)` — an unquoted value containing a colon — is invalid YAML, which breaks the page render. The set of invalid-frontmatter files matches the set of blank pages exactly (26/26); all older examples quote their titles.

**Fix:**
- Quote the 26 affected `title`/`description` values.
- `validate.js` now rejects unquoted frontmatter values containing `": "`, so `npm run validate` catches this class before it ships (verified: fails on the old content, passes on this branch).