### PR TITLE
docs(mcp): add Develop it live sections for Dev Mode

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -69,3 +69,5 @@ await client.close()
 npm init -y && npm install @modelcontextprotocol/client
 ENDPOINT="https://…/demo/mcp" node client.mjs
 ```
+
+Every Framework-hosted example here also runs under [Dev Mode](https://www.serverless.com/framework/docs/providers/aws/guide/mcp#dev-mode): `serverless dev` keeps the deployed endpoint (and its auth) live while each tool call runs your local working copy — the [minimal example shows the loop](minimal/README.md#develop-it-live).

--- a/mcp/minimal/README.md
+++ b/mcp/minimal/README.md
@@ -159,6 +159,18 @@ claude -p "call the add tool from the demo MCP server with a=2 b=40" --allowedTo
 
 The custom domain enters the picture only when a server enforces OAuth and a human logs in through the client — that walkthrough is the [oauth-cognito README](../oauth-cognito/README.md#interactive-clients-need-a-custom-domain). `claude mcp remove demo` deregisters it.
 
+## Develop it live
+
+Dev Mode serves this example while every tool call runs the module in your editor. Start a session:
+
+```bash
+serverless dev
+```
+
+The banner lists the same `/demo/mcp` endpoint — still a real API Gateway URL — and each request to it is relayed to your machine and answered by your current local code. Call a tool through any client, edit `src/server.mjs`, call it again: the second answer is the new code, with nothing deployed in between. TypeScript modules get the same treatment, compiled on the fly.
+
+Two limits come with a session. Requests or results larger than ~125 KB are rejected: the session prints the limit and what to do, while the client sees a plain `502`. And because a session delivers each result in one piece, a tool call that stays silent for roughly 30 seconds is dropped downstream with a `504` on an edge-optimized endpoint — this example's `endpointType: REGIONAL` has no such budget, so a call runs up to the server's `timeout`. Deploying normally lifts both — and when you are done developing, `serverless deploy` restores the packaged server on the same URL. The [Dev Mode section of the MCP guide](https://www.serverless.com/framework/docs/providers/aws/guide/mcp#dev-mode) covers the mechanics, including how `state` keys and elicitation behave during a session.
+
 ## Going further
 
 `serverless.yml` carries the next three steps as commented blocks, each with the reasoning next to it:

--- a/mcp/oauth-authorizer/README.md
+++ b/mcp/oauth-authorizer/README.md
@@ -230,6 +230,10 @@ curl -s -X POST https://your-tenant.us.auth0.com/oidc/register \
 
 The issuer's metadata advertises a `registration_endpoint` whether or not registration is actually enabled, so the probe — not the metadata — is what tells you.
 
+## Develop it live
+
+`serverless dev` works with the gate up — and here that cuts both ways: the authorizer function itself runs on your machine through the same session, so you can edit token verification and see the next request judged by the new code, while rejected requests still never reach the server. The [minimal example's walkthrough](../minimal/README.md#develop-it-live) and the [Dev Mode docs](https://www.serverless.com/framework/docs/providers/aws/guide/mcp#dev-mode) apply unchanged.
+
 ## Clean up
 
 ```bash

--- a/mcp/oauth-cognito/README.md
+++ b/mcp/oauth-cognito/README.md
@@ -232,6 +232,10 @@ The redirect completes the flow back to Claude:
 
 The logged-in calls then pass the gate. What makes them pass is scope: the pool authorizer accepts only access tokens carrying `mcp/invoke`, which is why the pre-registered client above enables `openid mcp/invoke` — and when a client's request names no scopes, Cognito issues the token with every scope enabled on the app client. If a post-login call answers `401` anyway, what the client sent to `/oauth2/authorize` is the first thing to check.
 
+## Develop it live
+
+`serverless dev` works with the gate up: during a session the user pool authorizer stays in force at API Gateway exactly as it does deployed — unauthorized requests are rejected there, and accepted requests run your local module on the next save — no redeploy. The [minimal example's walkthrough](../minimal/README.md#develop-it-live) and the [Dev Mode docs](https://www.serverless.com/framework/docs/providers/aws/guide/mcp#dev-mode) apply unchanged.
+
 ## Clean up
 
 ```bash

--- a/mcp/oauth-in-module/README.md
+++ b/mcp/oauth-in-module/README.md
@@ -189,6 +189,10 @@ claude -p "call the whoami tool from the demo MCP server and show the raw result
 
 A pasted header never refreshes, so calls start answering the gate's `401` when the token expires — re-add with a fresh one. `claude mcp remove demo` deregisters it. The browser-login alternative is the [oauth-cognito walkthrough](../oauth-cognito/README.md#interactive-clients-need-a-custom-domain), and it applies here the same way once a root-mapped domain fronts the service.
 
+## Develop it live
+
+`serverless dev` serves this example too — and since enforcement lives in the module here, the verification code is precisely what runs on your machine: edit it, and the next request is judged by the new logic, no redeploy. The [minimal example's walkthrough](../minimal/README.md#develop-it-live) and the [Dev Mode docs](https://www.serverless.com/framework/docs/providers/aws/guide/mcp#dev-mode) apply unchanged.
+
 ## Clean up
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a **Develop it live** section to each Framework-hosted MCP example README, plus a pointer in the hub, for running the examples under `serverless dev`.

- `mcp/minimal` — the full walkthrough: `serverless dev`, the deployed endpoint staying live, the edit → call loop, the two session limits and where each is reported, and `serverless deploy` restoring the packaged server; links the Dev Mode section of the MCP guide.
- `mcp/oauth-cognito` — the user pool authorizer stays in force at API Gateway during a session.
- `mcp/oauth-authorizer` — additionally, the authorizer function itself runs locally through the session.
- `mcp/oauth-in-module` — the in-module verification code is what runs locally.
- `mcp/README.md` (hub) — one-line pointer to the loop.

README-only; no deployable changes, and no index regeneration needed.

## Test plan

- [x] `npm run validate`
- [x] `mcp/minimal` exercised against AWS with a Framework build that includes MCP Dev Mode: deployed, started `serverless dev`, called `add` through the live endpoint (relayed and logged by the session), edited `src/server.mjs` and called again with the new result and no deploy, sent a ~200 KB request (the session printed the 125 KB limit; the client received a `502`), stopped the session, and `serverless deploy` restored the packaged server on the same URL.

## Related

- Companion to serverless/serverless#13836, which serves MCP servers through Dev Mode. Merge once the Framework release that includes it is out; the READMEs link the guide section that ships with it.
